### PR TITLE
fix!: do not return an error when `exists` key does not exist

### DIFF
--- a/wit/readwrite.wit
+++ b/wit/readwrite.wit
@@ -22,7 +22,5 @@ interface readwrite {
 	delete: func(bucket: bucket, key: key) -> result<_, error>
 
 	/// Check if the key exists in the bucket.
-	///
-	/// If the key does not exist in the bucket, it returns an error.
 	exists: func(bucket: bucket, key: key) -> result<bool, error>
 }


### PR DESCRIPTION
Currently `readwrite.exists` method must return an error for keys that do not exist, which makes the return value (`bool`) of that method redundant.
Remove the requirement to return an error to address this inconsistency.

Alternatively, the `bool` return value could be removed, but IMO `exists` would not be the right name for such method anymore