### PR TITLE
feat(*): major updates to the keyvalue interfaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         curl -Lo 'wit-deps' https://github.com/bytecodealliance/wit-deps/releases/download/v0.3.5/wit-deps-x86_64-unknown-linux-musl
         chmod +x wit-deps
         ./wit-deps lock --check
-    - uses: WebAssembly/wit-abi-up-to-date@v16
+    - uses: WebAssembly/wit-abi-up-to-date@v17
       with:
         worlds: 'keyvalue keyvalue-handle-watch'
-        wit-bindgen: '0.15.0'
+        wit-bindgen: '0.16.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,5 @@ jobs:
         ./wit-deps lock --check
     - uses: WebAssembly/wit-abi-up-to-date@v17
       with:
-        worlds: 'keyvalue keyvalue-handle-watch'
+        worlds: 'imports keyvalue-handle-watch'
         wit-bindgen: '0.16.0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: ensure `./wit/deps` are in sync
       run: |
-        curl -Lo 'wit-deps' https://github.com/bytecodealliance/wit-deps/releases/download/v0.3.3/wit-deps-x86_64-unknown-linux-musl
+        curl -Lo 'wit-deps' https://github.com/bytecodealliance/wit-deps/releases/download/v0.3.5/wit-deps-x86_64-unknown-linux-musl
         chmod +x wit-deps
         ./wit-deps lock --check
     - uses: WebAssembly/wit-abi-up-to-date@v16
       with:
         worlds: 'keyvalue keyvalue-handle-watch'
-        wit-bindgen: '0.13.0'
+        wit-bindgen: '0.15.0'

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This proposal was inspired by Dapr's [State API]
 ### Change log
 
 - 2023-11-30: 
-  - Changed the `get` and `get-many` and `get-keys` signatures
+  - Changed the `get` and `get-many` and `keys` signatures
   - Updated comments in all the interfaces.
   - Renamed `wasi-cloud-error` to `wasi-keyvalue-error`
 - 2023-05-17: Updated batch example to use one interface instead of 2

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Phase 1
 
 ### Portability Criteria
 
-`wasi:keyvalue` must have at least two implementations in terms of relevant mainstream key-value stores in each of the following categories: 
+`wasi:keyvalue` must have at least two implementations in terms of relevant mainstream key-value stores in each of the following categories:
 
 1. Open-source key-value stores like Redis, Memcached, Etcd etc.
 2. Proprietary key-value stores like AWS DynamoDB, Azure CosmosDB, Google Cloud Firestore etc.
@@ -24,26 +24,24 @@ The implementations must be able to run on Linux, MacOS, and Windows.
 A testsuite that passes on the platforms and implementations mentioned above.
 
 ## Table of Contents
-- [WASI Key-Value Store](#wasi-key-value-store)
-		- [Current Phase](#current-phase)
-		- [Champions](#champions)
-		- [Portability Criteria](#portability-criteria)
-	- [Table of Contents](#table-of-contents)
-		- [Introduction](#introduction)
-		- [Goals](#goals)
-		- [Non-goals](#non-goals)
-		- [API walk-through](#api-walk-through)
-			- [Use case 1](#use-case-1)
-			- [Use case 2](#use-case-2)
-		- [Detailed design discussion](#detailed-design-discussion)
-			- [Tricky design choice 1](#tricky-design-choice-1)
-			- [Tricky design choice 2](#tricky-design-choice-2)
-		- [Considered alternatives](#considered-alternatives)
-			- [Alternative 1](#alternative-1)
-			- [Alternative 2](#alternative-2)
-		- [Stakeholder Interest \& Feedback](#stakeholder-interest--feedback)
-		- [References \& acknowledgements](#references--acknowledgements)
-		- [Change log](#change-log)
+
+- [WASI Key-Value Store](#wasi-key-value-store) - [Current Phase](#current-phase) - [Champions](#champions) - [Portability Criteria](#portability-criteria)
+  - [Table of Contents](#table-of-contents)
+    - [Introduction](#introduction)
+    - [Goals](#goals)
+    - [Non-goals](#non-goals)
+    - [API walk-through](#api-walk-through)
+      - [Use case 1](#use-case-1)
+      - [Use case 2](#use-case-2)
+    - [Detailed design discussion](#detailed-design-discussion)
+      - [Tricky design choice 1](#tricky-design-choice-1)
+      - [Tricky design choice 2](#tricky-design-choice-2)
+    - [Considered alternatives](#considered-alternatives)
+      - [Alternative 1](#alternative-1)
+      - [Alternative 2](#alternative-2)
+    - [Stakeholder Interest \& Feedback](#stakeholder-interest--feedback)
+    - [References \& acknowledgements](#references--acknowledgements)
+    - [Change log](#change-log)
 
 ### Introduction
 
@@ -78,22 +76,25 @@ A third design goal of `wasi:keyvalue` interfaces is to allow performance optimi
 
 ### API walk-through
 
-The proposal can be understood by first reading the comments of `world.wit`, then `readwrite.wit`, `atomic.wit`, `batch.wit`, `caching.wit` and finally `types.wit`
+The proposal can be understood by first reading the comments of `world.wit`, then `eventual.wit`, `atomic.wit`, `eventual-batch.wit`, `caching.wit` and finally `types.wit`
 
 [`world.wit`](./wit/world.wit)
-[`readwrite.wit`](./wit/readwrite.wit)
+[`eventual.wit`](./wit/eventual.wit)
 [`atomic.wit`](./wit/atomic.wit)
-[`batch.wit`](./wit/batch.wit)
+[`eventual-batch.wit`](./wit/eventual-batch.wit)
 [`caching.wit`](./wit/caching.wit)
 [`types.wit`](./wit/types.wit)
 
 ### Working with the WIT
 
 Bindings can be generated from the `wit` directory via:
+
 ```
 wit-bindgen c wit/ --world proxy
 ```
+
 and can be validated and otherwise manipulated via:
+
 ```
 wasm-tools component wit wit/ ...
 ```
@@ -112,9 +113,12 @@ This proposal was inspired by Dapr's [State API]
 [State API](https://docs.dapr.io/developing-applications/building-blocks/state-management/)
 
 ### Change log
+
+- 2024-01-16:
+  - Changed the `readwrite` and `batch` interface names to `eventual` and `eventual-batch`. See more details [here](https://github.com/WebAssembly/wasi-keyvalue/pull/30#discussion_r1442282650).
 - 2023-12-19:
   - Changed the `size` to `incoming-value-size` and it's signature
-- 2023-11-30: 
+- 2023-11-30:
   - Changed the `get` and `get-many` and `keys` signatures
   - Updated comments in all the interfaces.
   - Renamed `wasi-cloud-error` to `wasi-keyvalue-error`
@@ -123,10 +127,10 @@ This proposal was inspired by Dapr's [State API]
 - 2023-02-13: The following changes were made to the API:
   - Added `bucket` type to the `types` interface.
   - Uses pseudo-stream and pseudo-resource types inspired from [wasi-io ](https://github.com/WebAssembly/wasi-io)
-  - Added *.wit files for the interfaces and worlds, which are verified by the [wasm-tools](https://github.com/bytecodealliance/wasm-tools)
+  - Added \*.wit files for the interfaces and worlds, which are verified by the [wasm-tools](https://github.com/bytecodealliance/wasm-tools)
   - Added a inbound-keyvalue interface that handles the `watch` operation.
 - 2023-01-28: The following changes were made to the API:
-  - Changed `stream<T>` type to `list<T>` type because `stream<T>` is not supported by the current version of [*.wit](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md).
-  - Removed the worlds section because the star import syntax is not supported by the current version of [*.wit](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)
+  - Changed `stream<T>` type to `list<T>` type because `stream<T>` is not supported by the current version of [\*.wit](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md).
+  - Removed the worlds section because the star import syntax is not supported by the current version of [\*.wit](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md)
 - 2022-11-29: Renamed `bulk-get` to `get-multi` and `bulk-set` to `set-multi` to be consistent with the naming convention of the other interfaces.
 - 2022-10-31: Initial draft

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ This proposal was inspired by Dapr's [State API]
 [State API](https://docs.dapr.io/developing-applications/building-blocks/state-management/)
 
 ### Change log
-
+- 2023-12-19:
+  - Changed the `size` to `incoming-value-size` and it's signature
 - 2023-11-30: 
   - Changed the `get` and `get-many` and `keys` signatures
   - Updated comments in all the interfaces.

--- a/README.md
+++ b/README.md
@@ -12,22 +12,19 @@ Phase 1
 - David Justice
 - Jiaxiao Zhou
 
-### Phase 4 Advancement Criteria
+### Portability Criteria
 
-At least two independent production implementations.
-
-At least two cloud provider implementations.
-
-Implementations available for at least Windows, Linux & MacOS.
+`wasi:keyvalue` must have at least two complete independent implementations demonstrating
+embeddability in a production key-value store context. The implementations must be able to run
+on at least two different operating systems.
 
 A testsuite that passes on the platforms and implementations mentioned above.
 
 ## Table of Contents
-
 - [WASI Key-Value Store](#wasi-key-value-store)
 		- [Current Phase](#current-phase)
 		- [Champions](#champions)
-		- [Phase 4 Advancement Criteria](#phase-4-advancement-criteria)
+		- [Portability Criteria](#portability-criteria)
 	- [Table of Contents](#table-of-contents)
 		- [Introduction](#introduction)
 		- [Goals](#goals)
@@ -47,300 +44,76 @@ A testsuite that passes on the platforms and implementations mentioned above.
 
 ### Introduction
 
-WASI Key-Value Store is a WASI API primarily for accessing a key-value datastore. It has functions to:
+This `wasi:keyvalue` proposal defines a collection of [interfaces] for
+interacting with key-value stores. It additionally defines a [world],
+`wasi:keyvalue/keyvalue`, that groups together common interfaces including
 
-1. retrieve the value stored and associated with a key,
-2. delete a key-value pair, and
-3. create and update a key-value pair.
+1. CRUD operations on single key-value pairs
+2. Atomic operations on single key-value pairs
+3. Batch operations on multiple key-value pairs
 
 The API is designed to hide data-plane differences between different key-value stores. The control-plane behavior/functionality (e.g., including cluster management, data consistency, replication, and sharding) are not specified, and are provider specific.
 
+[Interfaces]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#wit-interfaces
+[World]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#wit-worlds
+
 ### Goals
 
-The primary goal of this API is to allow users to use WASI programs to access key-value stores. It abstracts away the complexity of building stateful services that need to access key-value stores. In other words, it decouples the application code from the specific key-value store APIs. This allows WASI programs to be portable across different key-value store that supports this interface, be it on-prem, in the cloud, or in edge devices.
+The primary goal of this API is to allow WASI programs to access a wide variety of key-value stores. It meant the `wasi:keyvalue` interfaces to be implementable by a wide variety of key-value stores, including but not limited to: in-memory key-value stores, on-disk key-value stores, document databases, relational databases, and either single-node or distributed key-value stores.
 
-The second goal of this API is to abstract away the network stack, allowing applications that need to access key-value stores to not worry about what network protocol is used to access the key-value store.
+The second goal of `wasi:keyvalue` interfaces is to abstract away the network stack, allowing applications that need to access key-value stores to not worry about what network protocol is used to access the key-value store.
+
+A third design goal of `wasi:keyvalue` interfaces is to allow performance optimizations without compromising the portability of the API. This includes minimizing the number of copies of data, minimizing the number of requests and round-trips, and support for asynchronous operations.
 
 ### Non-goals
 
-- Cover all application requirements for a key-value store. Instead, it focuses on the most common use cases. It allows providers to extend the API to support more use cases.
-- Transactional semantics.
-- Data consistency.
-- Data replication.
-- Data sharding.
-- Cluster management.
-- Monitoring
+- The `wasi:keyvalue` interfaces only focus on the most common use cases for key-value stores. It does not attempt to cover all possible use cases.
+- The `wasi:keyvalue` interfaces do not guarantee data consistency. Data consistency models (eventual, strong, casual etc.) are diverse and are specific to each key-value store's architecture. The implication is that components importing `wasi:keyvalue` interfaces would need to be aware of the data consistency model of the key-value store they are using.
+- The `wasi:keyvalue` interfaces do not handle data replication and sharding. These are control-plane behaviors that are specific to each key-value store's architecture. Replication needs and sharding management are left to the outside of the `wasi:keyvalue` interfaces.
+- No cluster management is provided. Operational aspects like scaling, node management, and cluster health are to be managed separately from the wasi:keyvalue interface `wasi:keyvalue` interfaces.
+- No built-in monitoring. Monitoring of key-value store performance and health should be done using external tools and not be expected as part of the `wasi:keyvalue` interfaces.
 
 ### API walk-through
 
-#### Use case 1
+The proposal can be understood by first reading the comments of `world.wit`, then `readwrite.wit`, `atomic.wit`, `batch.wit`, `caching.wit` and finally `types.wit`
 
-Imagine you have an HTTP handler that needs to persist some data to a key-value store. The handler needs to be able to retrieve, delete, and update the data in the key-value store. The following Rust and Go code shows how you can use the WASI Key-Value Store API to in the handler.
+[`world.wit`](./wit/world.wit)
+[`readwrite.wit`](./wit/readwrite.wit)
+[`atomic.wit`](./wit/atomic.wit)
+[`batch.wit`](./wit/batch.wit)
+[`caching.wit`](./wit/caching.wit)
+[`types.wit`](./wit/types.wit)
 
-```rust
-wit_bindgen::generate!("outbound-keyvalue" in "wit/world.wit");
-use types::{ open_bucket, drop_bucket, payload_consume_sync };
-use readwrite::{ get, set, exists };
-{
-  let my_bucket = open_bucket("my-bucket")?;
-  set(my_bucket, "my-key", "my-value")?;
-  if exists(my_bucket, "my-key")? {
-    let payload = get(my_bucket, "my-key")?;
-    let body: Vec<u8> = payload_consume_sync(payload)?;
-    let body = String::from_utf8(body)?;
-    println!("body: {}", body);
-  }
-  drop_bucket(my_bucket);
-}
+### Working with the WIT
+
+Bindings can be generated from the `wit` directory via:
+```
+wit-bindgen c wit/ --world proxy
+```
+and can be validated and otherwise manipulated via:
+```
+wasm-tools component wit wit/ ...
 ```
 
-```go
-bucket, err := types.OpenBucket("my-bucket")
-if err != nil {
-  panic(err)
-}
-defer types.DropBucket(bucket)
-
-err := readwrite.Set(bucket, "my-key", "my-value")
-if err != nil {
-  panic(err)
-}
-
-exists, err := readwrite.Exists(bucket, "my-key")
-if exists {
-  payload, err := readwrite.Get(bucket, "my-key")
-  if err != nil {
-    panic(err)
-  }
-  body, err := types.PayloadConsumeSync(payload)
-  if err != nil {
-    panic(err)
-  }
-  fmt.Println("body: ", string(body))
-}
-```
-
-#### Use case 2
-
-If you want to watch for changes to a key-value store, you can write a wasm component that uses the inbound-keyvalue interface this API provides. The following Rust code shows how you can use the WASI Key-Value Store API to watch for changes to a key-value store.
-
-```rust
-wit_bindgen::generate!("inbound-keyvalue" in "wit/world.wit");
-struct Handler;
-
-impl inbound_keyvalue::HandleWatch for Handler {
-  fn on_set(&mut self, bucket: Bucket, key: Key, value: Payload) {
-    let payload = get(my_bucket, "my-key").unwrap();
-    let body: Vec<u8> = payload_consume_sync(payload).unwrap();
-    let body = String::from_utf8(body).unwrap();
-    println!("bucket: {}, key: {}, value: {}", bucket, key, body);
-  }
-  fn on_delete(&mut self, bucket: Bucket, key: Key) {
-    println!("bucket: {}, key: {}", bucket, key);
-  }
-}
-
-```
-
-### Detailed design discussion
-
-```go
-/// A keyvalue interface that provides simple read and write operations.
-interface readwrite {
-	/// A keyvalue interface that provides simple read and write operations.
-	use types.{bucket, error, incoming-value, key, outgoing-value}
-	
-	/// Get the value associated with the key in the bucket. It returns a incoming-value
-	/// that can be consumed to get the value.
-	///
-	/// If the key does not exist in the bucket, it returns an error.
-	get: func(bucket: bucket, key: key) -> result<incoming-value, error>
-
-	/// Set the value associated with the key in the bucket. If the key already
-	/// exists in the bucket, it overwrites the value.
-	///
-	/// If the key does not exist in the bucket, it creates a new key-value pair.
-	/// If any other error occurs, it returns an error.
-	set: func(bucket: bucket, key: key, outgoing-value: outgoing-value) -> result<_, error>
-
-	/// Delete the key-value pair associated with the key in the bucket.
-	///
-	/// If the key does not exist in the bucket, it returns an error.
-	delete: func(bucket: bucket, key: key) -> result<_, error>
-
-	/// Check if the key exists in the bucket.
-	///
-	/// If the key does not exist in the bucket, it returns an error.
-	exists: func(bucket: bucket, key: key) -> result<bool, error>
-}
-/// A keyvalue interface that provides atomic operations.
-interface atomic {
-	/// A keyvalue interface that provides atomic operations.
-	use types.{bucket, error, key}
-
-	/// Atomically increment the value associated with the key in the bucket by the 
-	/// given delta. It returns the new value.
-	///
-	/// If the key does not exist in the bucket, it creates a new key-value pair
-	/// with the value set to the given delta. 
-	///
-	/// If any other error occurs, it returns an error.
-	increment: func(bucket: bucket, key: key, delta: u64) -> result<u64, error>
-	
-	/// Atomically compare and swap the value associated with the key in the bucket.
-	/// It returns a boolean indicating if the swap was successful.
-	///
-	/// If the key does not exist in the bucket, it returns an error.
-	compare-and-swap: func(bucket: bucket, key: key, old: u64, new: u64) -> result<bool, error>
-}
-
-/// A keyvalue interface that provides batch operations.
-interface batch {
-	/// A keyvalue interface that provides batch get operations.
-	use types.{bucket, error, key, keys, incoming-value, outgoing-value}
-
-	/// Get the values associated with the keys in the bucket. It returns a list of
-	/// incoming-values that can be consumed to get the values.
-	///
-	/// If any of the keys do not exist in the bucket, it returns an error.
-	get-many: func(bucket: bucket, keys: keys) -> result<list<incoming-value>, error>
-
-	/// Get all the keys in the bucket. It returns a list of keys.
-	get-keys: func(bucket: bucket) -> keys
-
-	/// Set the values associated with the keys in the bucket. If the key already
-	/// exists in the bucket, it overwrites the value.
-	///
-	/// If any of the keys do not exist in the bucket, it creates a new key-value pair.
-	/// If any other error occurs, it returns an error.
-	set-many: func(bucket: bucket, key-values: list<tuple<key, outgoing-value>>) -> result<_, error>
-
-	/// Delete the key-value pairs associated with the keys in the bucket.
-	///
-	/// If any of the keys do not exist in the bucket, it skips the key.
-	/// If any other error occurs, it returns an error.
-	delete-many: func(bucket: bucket, keys: keys) -> result<_, error>
-}
-
-// A generic keyvalue interface for WASI.
-interface types {
-	/// A bucket is a collection of key-value pairs. Each key-value pair is stored
-	/// as a entry in the bucket, and the bucket itself acts as a collection of all
-	/// these entries. 
-	///
-	/// It is worth noting that the exact terminology for bucket in key-value stores
-	/// can very depending on the specific implementation. For example,
-	/// 1. Amazon DynamoDB calls a collection of key-value pairs a table
-	/// 2. Redis has hashes, sets, and sorted sets as different types of collections
-	/// 3. Cassandra calls a collection of key-value pairs a column family
-	/// 4. MongoDB calls a collection of key-value pairs a collection
-	/// 5. Riak calls a collection of key-value pairs a bucket
-	/// 6. Memcached calls a collection of key-value pairs a slab
-	/// 7. Azure Cosmos DB calls a collection of key-value pairs a container
-	///
-	/// In this interface, we use the term `bucket` to refer to a collection of key-value
-	// Soon: switch to `resource bucket { ... }`
-	type bucket = u32
-	drop-bucket: func(bucket: bucket)
-	open-bucket: func(name: string) -> result<bucket, error>
-
-	/// A key is a unique identifier for a value in a bucket. The key is used to
-	/// retrieve the value from the bucket.
-	type key = string
-
-	/// A list of keys
-	type keys = list<key>
-
-	use wasi:io/streams.{input-stream, output-stream}
-	use wasi-cloud-error.{ error }
-	/// A value is the data stored in a key-value pair. The value can be of any type
-	/// that can be represented in a byte array. It provides a way to write the value
-	/// to the output-stream defined in the `wasi-io` interface.
-	// Soon: switch to `resource value { ... }`
-	type outgoing-value = u32
-	drop-outgoing-value: func(outgoing-value: outgoing-value)
-	new-outgoing-value: func() -> outgoing-value
-	outgoing-value-write-body: func(outgoing-value: outgoing-value) -> result<output-stream>
-
-	/// A incoming-value is a wrapper around a value. It provides a way to read the value
-	/// from the input-stream defined in the `wasi-io` interface.
-	///
-	/// The incoming-value provides two ways to consume the value:
-	/// 1. `incoming-value-consume-sync` consumes the value synchronously and returns the
-	///    value as a list of bytes.
-	/// 2. `incoming-value-consume-async` consumes the value asynchronously and returns the
-	///    value as an input-stream.
-	// Soon: switch to `resource incoming-value { ... }`
-	type incoming-value = u32
-	type incoming-value-async-body = input-stream
-	type incoming-value-sync-body = list<u8>
-	drop-incoming-value: func(incoming-value: incoming-value)
-	incoming-value-consume-sync: func(incoming-value: incoming-value) -> result<incoming-value-sync-body, error>
-	incoming-value-consume-async: func(incoming-value: incoming-value) -> result<incoming-value-async-body, error>
-	size: func(incoming-value: incoming-value) -> u64
-}
-```
-
-- The `get-many` and `set-many` are atomic.
-- The `increment` is atomic, in a way that it is a small transaction of get, increment, and set operations on the same key.
-
-The following interfaces are still under discussion:
-
-```go
-interface transaction {
-  // transaction is an atomic operation that groups multiple operations together.
-  // If any operation fails, all operations in the transaction are rolled back.
-  use types.{ Error, payload, key }
-
-  get-multi: func(keys: keys) -> result<list<payload>, Error>
-  
-  set-multi: func(key_values: list<(key, list<u8>)>) -> result<_, Error>
-}
-
-interface ttl {
-  use types.{ Error, key }
-  
-  set-with-ttl: func(key: key, value: list<u8>, ttl: u64) -> result<_, Error>
-}
-
-interface "wasi:kv/data/query" { 
-  ...
-}
-```
-
-#### Tricky design choice 1
-
-TODO
-
-#### Tricky design choice 2
-
-TODO
-
-### Considered alternatives
-
-TODO
-
-#### Alternative 1
-
-TODO
-#### Alternative 2
-
-TODO
-
-### Stakeholder Interest & Feedback
-
-TODO before entering Phase 3.
+The `wit/deps` directory contains a live snapshot of the contents of several
+other WASI proposals upon which this proposal depends. It is automatically
+updated by running [`wit-deps update`](https://crates.io/crates/wit-deps-cli)
+in the root directory, which fetches the live contents of the `main` branch of
+each proposal. As things stabilize, `wit/deps.toml` will be updated to refer to
+versioned releases.
 
 ### References & acknowledgements
 
-Many thanks for valuable feedback and advice from:
+This proposal was inspired by Dapr's [State API]
 
-- [Person 1]
-- [Person 2]
-- [etc.]
+[State API](https://docs.dapr.io/developing-applications/building-blocks/state-management/)
 
 ### Change log
 
+- 2023-11-30: 
+  - Changed the `get` and `get-many` and `get-keys` signatures
+  - Updated comments in all the interfaces.
+  - Renamed `wasi-cloud-error` to `wasi-keyvalue-error`
 - 2023-05-17: Updated batch example to use one interface instead of 2
 - 2023-05-25: Change the WITs to the newest syntax.
 - 2023-02-13: The following changes were made to the API:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Phase 1
 
 ### Portability Criteria
 
-`wasi:keyvalue` must have at least two complete independent implementations demonstrating
-embeddability in a production key-value store context. The implementations must be able to run
-on at least two different operating systems.
+`wasi:keyvalue` must have at least two implementations in terms of relevant mainstream key-value stores in each of the following categories: 
+
+1. Open-source key-value stores like Redis, Memcached, Etcd etc.
+2. Proprietary key-value stores like AWS DynamoDB, Azure CosmosDB, Google Cloud Firestore etc.
+
+The implementations must be able to run on Linux, MacOS, and Windows.
 
 A testsuite that passes on the platforms and implementations mentioned above.
 

--- a/imports.md
+++ b/imports.md
@@ -15,9 +15,9 @@ do</p>
 <li>interface <a href="#wasi:io_streams_0.2.0_rc_2023_11_10"><code>wasi:io/streams@0.2.0-rc-2023-11-10</code></a></li>
 <li>interface <a href="#wasi:keyvalue_wasi_keyvalue_error"><code>wasi:keyvalue/wasi-keyvalue-error</code></a></li>
 <li>interface <a href="#wasi:keyvalue_types"><code>wasi:keyvalue/types</code></a></li>
-<li>interface <a href="#wasi:keyvalue_readwrite"><code>wasi:keyvalue/readwrite</code></a></li>
+<li>interface <a href="#wasi:keyvalue_eventual"><code>wasi:keyvalue/eventual</code></a></li>
 <li>interface <a href="#wasi:keyvalue_atomic"><code>wasi:keyvalue/atomic</code></a></li>
-<li>interface <a href="#wasi:keyvalue_batch"><code>wasi:keyvalue/batch</code></a></li>
+<li>interface <a href="#wasi:keyvalue_eventual_batch"><code>wasi:keyvalue/eventual-batch</code></a></li>
 </ul>
 </li>
 </ul>
@@ -585,9 +585,9 @@ If the size is unknown or unavailable, this function returns an <code>Err(error)
 <ul>
 <li><a name="method_incoming_value.incoming_value_size.0"></a> result&lt;<code>u64</code>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
-<h2><a name="wasi:keyvalue_readwrite">Import interface wasi:keyvalue/readwrite</a></h2>
-<p>A keyvalue interface that provides simple read and write operations.</p>
-<p>A read/write operation is an operation that acts on a single key-value pair.</p>
+<h2><a name="wasi:keyvalue_eventual">Import interface wasi:keyvalue/eventual</a></h2>
+<p>A keyvalue interface that provides eventually consistent CRUD operations.</p>
+<p>A CRUD operation is an operation that acts on a single key-value pair.</p>
 <p>The value in the key-value pair is defined as a <code>u8</code> byte array and the intention
 is that it is the common denominator for all data types defined by different
 key-value stores to handle data, ensuring compatibility between different
@@ -732,8 +732,8 @@ and was replaced with the <code>new</code> value.</p>
 <ul>
 <li><a name="compare_and_swap.0"></a> result&lt;<code>bool</code>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
-<h2><a name="wasi:keyvalue_batch">Import interface wasi:keyvalue/batch</a></h2>
-<p>A keyvalue interface that provides batch operations.</p>
+<h2><a name="wasi:keyvalue_eventual_batch">Import interface wasi:keyvalue/eventual-batch</a></h2>
+<p>A keyvalue interface that provides eventually consistent batch operations.</p>
 <p>A batch operation is an operation that operates on multiple keys at once.</p>
 <p>Batch operations are useful for reducing network round-trip time. For example,
 if you want to get the values associated with 100 keys, you can either do 100 get

--- a/imports.md
+++ b/imports.md
@@ -439,7 +439,8 @@ or does not have the required permissions to perform the operation.</li>
 </ul>
 <h2>Currently, this provides only one function to return a string representation
 of the error. In the future, this will be extended to provide more information
-about the error.</h2>
+about the error.
+Soon: switch to <code>resource error { ... }</code></h2>
 <h3>Functions</h3>
 <h4><a name="method_error.trace"><code>[method]error.trace: func</code></a></h4>
 <h5>Params</h5>
@@ -451,6 +452,7 @@ about the error.</h2>
 <li><a name="method_error.trace.0"></a> <code>string</code></li>
 </ul>
 <h2><a name="wasi:keyvalue_types">Import interface wasi:keyvalue/types</a></h2>
+<p>A generic keyvalue interface for WASI.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="input_stream"><code>type input-stream</code></a></h4>
@@ -477,7 +479,8 @@ can very depending on the specific implementation. For example,</p>
 <li>Memcached calls a collection of key-value pairs a slab</li>
 <li>Azure Cosmos DB calls a collection of key-value pairs a container</li>
 </ol>
-<p>In this interface, we use the term <a href="#bucket"><code>bucket</code></a> to refer to a collection of key-value</p>
+<p>In this interface, we use the term <a href="#bucket"><code>bucket</code></a> to refer to a collection of key-value
+Soon: switch to <code>resource bucket { ... }</code></p>
 <h4><a name="key"><code>type key</code></a></h4>
 <p><code>string</code></p>
 <p>A key is a unique identifier for a value in a bucket. The key is used to
@@ -485,7 +488,8 @@ retrieve the value from the bucket.
 <h4><a name="outgoing_value"><code>resource outgoing-value</code></a></h4>
 <p>A value is the data stored in a key-value pair. The value can be of any type
 that can be represented in a byte array. It provides a way to write the value
-to the output-stream defined in the <code>wasi-io</code> interface.</p>
+to the output-stream defined in the <code>wasi-io</code> interface.
+Soon: switch to <code>resource value { ... }</code></p>
 <h4><a name="outgoing_value_body_async"><code>type outgoing-value-body-async</code></a></h4>
 <p><a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></p>
 <p>
@@ -503,7 +507,8 @@ value as a <code>list&lt;u8&gt;</code>.</li>
 value as an <a href="#input_stream"><code>input-stream</code></a>.
 In addition, it provides a <code>incoming-value-size</code> function to get the size of the value.
 This is useful when the value is large and the caller wants to allocate a buffer of
-the right size to consume the value.</li>
+the right size to consume the value.
+Soon: switch to <code>resource incoming-value { ... }</code></li>
 </ol>
 <h4><a name="incoming_value_async_body"><code>type incoming-value-async-body</code></a></h4>
 <p><a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></p>

--- a/imports.md
+++ b/imports.md
@@ -1,5 +1,5 @@
-<h1><a name="keyvalue">World keyvalue</a></h1>
-<p>The <code>wasi:keyvalue/keyvalue</code> world provides common APIs for interacting
+<h1><a name="imports">World imports</a></h1>
+<p>The <code>wasi:keyvalue/imports</code> world provides common APIs for interacting
 with key-value stores. Components targeting this world will be able to
 do</p>
 <ol>

--- a/keyvalue-handle-watch.md
+++ b/keyvalue-handle-watch.md
@@ -491,13 +491,16 @@ to the output-stream defined in the <code>wasi-io</code> interface.</p>
 <p>
 #### <a name="incoming_value">`resource incoming-value`</a>
 <p>A incoming-value is a wrapper around a value. It provides a way to read the value
-from the input-stream defined in the <code>wasi-io</code> interface.</p>
+from the <a href="#input_stream"><code>input-stream</code></a> defined in the <code>wasi-io</code> interface.</p>
 <p>The incoming-value provides two ways to consume the value:</p>
 <ol>
 <li><code>incoming-value-consume-sync</code> consumes the value synchronously and returns the
-value as a list of bytes.</li>
+value as a <code>list&lt;u8&gt;</code>.</li>
 <li><code>incoming-value-consume-async</code> consumes the value asynchronously and returns the
-value as an input-stream.</li>
+value as an <a href="#input_stream"><code>input-stream</code></a>.
+In addition, it provides a <code>incoming-value-size</code> function to get the size of the value.
+This is useful when the value is large and the caller wants to allocate a buffer of
+the right size to consume the value.</li>
 </ol>
 <h4><a name="incoming_value_async_body"><code>type incoming-value-async-body</code></a></h4>
 <p><a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></p>
@@ -508,6 +511,8 @@ value as an input-stream.</li>
 ----
 <h3>Functions</h3>
 <h4><a name="static_bucket.open_bucket"><code>[static]bucket.open-bucket: func</code></a></h4>
+<p>Opens a bucket with the given name.</p>
+<p>If any error occurs, including if the bucket does not exist, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="static_bucket.open_bucket.name"><code>name</code></a>: <code>string</code></li>
@@ -522,6 +527,8 @@ value as an input-stream.</li>
 <li><a name="static_outgoing_value.new_outgoing_value.0"></a> own&lt;<a href="#outgoing_value"><a href="#outgoing_value"><code>outgoing-value</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_outgoing_value.outgoing_value_write_body_async"><code>[method]outgoing-value.outgoing-value-write-body-async: func</code></a></h4>
+<p>Writes the value to the output-stream asynchronously.
+If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_outgoing_value.outgoing_value_write_body_async.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_value"><a href="#outgoing_value"><code>outgoing-value</code></a></a>&gt;</li>
@@ -531,6 +538,8 @@ value as an input-stream.</li>
 <li><a name="method_outgoing_value.outgoing_value_write_body_async.0"></a> result&lt;own&lt;<a href="#outgoing_value_body_async"><a href="#outgoing_value_body_async"><code>outgoing-value-body-async</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_outgoing_value.outgoing_value_write_body_sync"><code>[method]outgoing-value.outgoing-value-write-body-sync: func</code></a></h4>
+<p>Writes the value to the output-stream synchronously.
+If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_outgoing_value.outgoing_value_write_body_sync.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_value"><a href="#outgoing_value"><code>outgoing-value</code></a></a>&gt;</li>
@@ -541,6 +550,8 @@ value as an input-stream.</li>
 <li><a name="method_outgoing_value.outgoing_value_write_body_sync.0"></a> result&lt;_, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_incoming_value.incoming_value_consume_sync"><code>[method]incoming-value.incoming-value-consume-sync: func</code></a></h4>
+<p>Consumes the value synchronously and returns the value as a list of bytes.
+If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_value.incoming_value_consume_sync.self"><code>self</code></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
@@ -550,6 +561,8 @@ value as an input-stream.</li>
 <li><a name="method_incoming_value.incoming_value_consume_sync.0"></a> result&lt;<a href="#incoming_value_sync_body"><a href="#incoming_value_sync_body"><code>incoming-value-sync-body</code></a></a>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_incoming_value.incoming_value_consume_async"><code>[method]incoming-value.incoming-value-consume-async: func</code></a></h4>
+<p>Consumes the value asynchronously and returns the value as an <a href="#input_stream"><code>input-stream</code></a>.
+If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_value.incoming_value_consume_async.self"><code>self</code></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
@@ -558,14 +571,16 @@ value as an input-stream.</li>
 <ul>
 <li><a name="method_incoming_value.incoming_value_consume_async.0"></a> result&lt;own&lt;<a href="#incoming_value_async_body"><a href="#incoming_value_async_body"><code>incoming-value-async-body</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="method_incoming_value.size"><code>[method]incoming-value.size: func</code></a></h4>
+<h4><a name="method_incoming_value.incoming_value_size"><code>[method]incoming-value.incoming-value-size: func</code></a></h4>
+<p>The size of the value in bytes.
+If the size is unknown or unavailable, this function returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="method_incoming_value.size.self"><code>self</code></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
+<li><a name="method_incoming_value.incoming_value_size.self"><code>self</code></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_incoming_value.size.0"></a> <code>u64</code></li>
+<li><a name="method_incoming_value.incoming_value_size.0"></a> result&lt;<code>u64</code>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h2><a name="wasi:keyvalue_readwrite">Import interface wasi:keyvalue/readwrite</a></h2>
 <p>A keyvalue interface that provides simple read and write operations.</p>

--- a/keyvalue-handle-watch.md
+++ b/keyvalue-handle-watch.md
@@ -436,7 +436,8 @@ or does not have the required permissions to perform the operation.</li>
 </ul>
 <h2>Currently, this provides only one function to return a string representation
 of the error. In the future, this will be extended to provide more information
-about the error.</h2>
+about the error.
+Soon: switch to <code>resource error { ... }</code></h2>
 <h3>Functions</h3>
 <h4><a name="method_error.trace"><code>[method]error.trace: func</code></a></h4>
 <h5>Params</h5>
@@ -448,6 +449,7 @@ about the error.</h2>
 <li><a name="method_error.trace.0"></a> <code>string</code></li>
 </ul>
 <h2><a name="wasi:keyvalue_types">Import interface wasi:keyvalue/types</a></h2>
+<p>A generic keyvalue interface for WASI.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="input_stream"><code>type input-stream</code></a></h4>
@@ -474,7 +476,8 @@ can very depending on the specific implementation. For example,</p>
 <li>Memcached calls a collection of key-value pairs a slab</li>
 <li>Azure Cosmos DB calls a collection of key-value pairs a container</li>
 </ol>
-<p>In this interface, we use the term <a href="#bucket"><code>bucket</code></a> to refer to a collection of key-value</p>
+<p>In this interface, we use the term <a href="#bucket"><code>bucket</code></a> to refer to a collection of key-value
+Soon: switch to <code>resource bucket { ... }</code></p>
 <h4><a name="key"><code>type key</code></a></h4>
 <p><code>string</code></p>
 <p>A key is a unique identifier for a value in a bucket. The key is used to
@@ -482,7 +485,8 @@ retrieve the value from the bucket.
 <h4><a name="outgoing_value"><code>resource outgoing-value</code></a></h4>
 <p>A value is the data stored in a key-value pair. The value can be of any type
 that can be represented in a byte array. It provides a way to write the value
-to the output-stream defined in the <code>wasi-io</code> interface.</p>
+to the output-stream defined in the <code>wasi-io</code> interface.
+Soon: switch to <code>resource value { ... }</code></p>
 <h4><a name="outgoing_value_body_async"><code>type outgoing-value-body-async</code></a></h4>
 <p><a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></p>
 <p>
@@ -500,7 +504,8 @@ value as a <code>list&lt;u8&gt;</code>.</li>
 value as an <a href="#input_stream"><code>input-stream</code></a>.
 In addition, it provides a <code>incoming-value-size</code> function to get the size of the value.
 This is useful when the value is large and the caller wants to allocate a buffer of
-the right size to consume the value.</li>
+the right size to consume the value.
+Soon: switch to <code>resource incoming-value { ... }</code></li>
 </ol>
 <h4><a name="incoming_value_async_body"><code>type incoming-value-async-body</code></a></h4>
 <p><a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></p>

--- a/keyvalue-handle-watch.md
+++ b/keyvalue-handle-watch.md
@@ -669,7 +669,7 @@ at all.</p>
 <h3>Functions</h3>
 <h4><a name="increment"><code>increment: func</code></a></h4>
 <p>Atomically increment the value associated with the key in the bucket by the
-given delta. It returns the new value. This is single, indivisible operation.</p>
+given delta. It returns the new value. This is a single, indivisible operation.</p>
 <p>If the key does not exist in the bucket, it creates a new key-value pair
 with the value set to the given delta.</p>
 <p>If any other error occurs, it returns an error.</p>

--- a/keyvalue-handle-watch.md
+++ b/keyvalue-handle-watch.md
@@ -7,9 +7,9 @@
 <li>interface <a href="#wasi:io_streams_0.2.0_rc_2023_11_10"><code>wasi:io/streams@0.2.0-rc-2023-11-10</code></a></li>
 <li>interface <a href="#wasi:keyvalue_wasi_keyvalue_error"><code>wasi:keyvalue/wasi-keyvalue-error</code></a></li>
 <li>interface <a href="#wasi:keyvalue_types"><code>wasi:keyvalue/types</code></a></li>
-<li>interface <a href="#wasi:keyvalue_readwrite"><code>wasi:keyvalue/readwrite</code></a></li>
+<li>interface <a href="#wasi:keyvalue_eventual"><code>wasi:keyvalue/eventual</code></a></li>
 <li>interface <a href="#wasi:keyvalue_atomic"><code>wasi:keyvalue/atomic</code></a></li>
-<li>interface <a href="#wasi:keyvalue_batch"><code>wasi:keyvalue/batch</code></a></li>
+<li>interface <a href="#wasi:keyvalue_eventual_batch"><code>wasi:keyvalue/eventual-batch</code></a></li>
 </ul>
 </li>
 <li>Exports:
@@ -582,9 +582,9 @@ If the size is unknown or unavailable, this function returns an <code>Err(error)
 <ul>
 <li><a name="method_incoming_value.incoming_value_size.0"></a> result&lt;<code>u64</code>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
-<h2><a name="wasi:keyvalue_readwrite">Import interface wasi:keyvalue/readwrite</a></h2>
-<p>A keyvalue interface that provides simple read and write operations.</p>
-<p>A read/write operation is an operation that acts on a single key-value pair.</p>
+<h2><a name="wasi:keyvalue_eventual">Import interface wasi:keyvalue/eventual</a></h2>
+<p>A keyvalue interface that provides eventually consistent CRUD operations.</p>
+<p>A CRUD operation is an operation that acts on a single key-value pair.</p>
 <p>The value in the key-value pair is defined as a <code>u8</code> byte array and the intention
 is that it is the common denominator for all data types defined by different
 key-value stores to handle data, ensuring compatibility between different
@@ -729,8 +729,8 @@ and was replaced with the <code>new</code> value.</p>
 <ul>
 <li><a name="compare_and_swap.0"></a> result&lt;<code>bool</code>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
-<h2><a name="wasi:keyvalue_batch">Import interface wasi:keyvalue/batch</a></h2>
-<p>A keyvalue interface that provides batch operations.</p>
+<h2><a name="wasi:keyvalue_eventual_batch">Import interface wasi:keyvalue/eventual-batch</a></h2>
+<p>A keyvalue interface that provides eventually consistent batch operations.</p>
 <p>A batch operation is an operation that operates on multiple keys at once.</p>
 <p>Batch operations are useful for reducing network round-trip time. For example,
 if you want to get the values associated with 100 keys, you can either do 100 get

--- a/keyvalue-handle-watch.md
+++ b/keyvalue-handle-watch.md
@@ -5,7 +5,7 @@
 <li>interface <a href="#wasi:io_error_0.2.0_rc_2023_11_10"><code>wasi:io/error@0.2.0-rc-2023-11-10</code></a></li>
 <li>interface <a href="#wasi:io_poll_0.2.0_rc_2023_11_10"><code>wasi:io/poll@0.2.0-rc-2023-11-10</code></a></li>
 <li>interface <a href="#wasi:io_streams_0.2.0_rc_2023_11_10"><code>wasi:io/streams@0.2.0-rc-2023-11-10</code></a></li>
-<li>interface <a href="#wasi:keyvalue_wasi_cloud_error"><code>wasi:keyvalue/wasi-cloud-error</code></a></li>
+<li>interface <a href="#wasi:keyvalue_wasi_keyvalue_error"><code>wasi:keyvalue/wasi-keyvalue-error</code></a></li>
 <li>interface <a href="#wasi:keyvalue_types"><code>wasi:keyvalue/types</code></a></li>
 <li>interface <a href="#wasi:keyvalue_readwrite"><code>wasi:keyvalue/readwrite</code></a></li>
 <li>interface <a href="#wasi:keyvalue_atomic"><code>wasi:keyvalue/atomic</code></a></li>
@@ -419,12 +419,22 @@ is ready for reading, before performing the <code>splice</code>.</p>
 <ul>
 <li><a name="method_output_stream.blocking_splice.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h2><a name="wasi:keyvalue_wasi_cloud_error">Import interface wasi:keyvalue/wasi-cloud-error</a></h2>
+<h2><a name="wasi:keyvalue_wasi_keyvalue_error">Import interface wasi:keyvalue/wasi-keyvalue-error</a></h2>
 <hr />
 <h3>Types</h3>
 <h4><a name="error"><code>resource error</code></a></h4>
-<h2>An error resource type for keyvalue operations.
-Currently, this provides only one function to return a string representation
+<p>An error resource type for keyvalue operations.</p>
+<p>Common errors:</p>
+<ul>
+<li>Connectivity errors (e.g. network errors): when the client cannot establish
+a connection to the keyvalue service.</li>
+<li>Autnetication and Authorization errors: when the client fails to authenticate
+or does not have the required permissions to perform the operation.</li>
+<li>Data errors: when the client sends incompatible or corrupted data.</li>
+<li>Resource errors: when the system runs out of resources (e.g. memory).</li>
+<li>Internal errors: unexpected errors on the server side.</li>
+</ul>
+<h2>Currently, this provides only one function to return a string representation
 of the error. In the future, this will be extended to provide more information
 about the error.</h2>
 <h3>Functions</h3>
@@ -582,9 +592,11 @@ value as an input-stream.</li>
 ----
 <h3>Functions</h3>
 <h4><a name="get"><code>get: func</code></a></h4>
-<p>Get the value associated with the key in the bucket. It returns a incoming-value
-that can be consumed to get the value.</p>
-<p>If the key does not exist in the bucket, it returns an error.</p>
+<p>Get the value associated with the key in the bucket.</p>
+<p>The value is returned as an option. If the key-value pair exists in the
+bucket, it returns ok with the value. If the key does not exist in the
+bucket, it returns ok with none.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="get.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -592,13 +604,13 @@ that can be consumed to get the value.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get.0"></a> result&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
+<li><a name="get.0"></a> result&lt;option&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="set"><code>set: func</code></a></h4>
 <p>Set the value associated with the key in the bucket. If the key already
 exists in the bucket, it overwrites the value.</p>
-<p>If the key does not exist in the bucket, it creates a new key-value pair.
-If any other error occurs, it returns an error.</p>
+<p>If the key does not exist in the bucket, it creates a new key-value pair.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="set.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -611,7 +623,8 @@ If any other error occurs, it returns an error.</p>
 </ul>
 <h4><a name="delete"><code>delete: func</code></a></h4>
 <p>Delete the key-value pair associated with the key in the bucket.</p>
-<p>If the key does not exist in the bucket, it returns an error.</p>
+<p>If the key does not exist in the bucket, it does nothing.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="delete.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -623,6 +636,9 @@ If any other error occurs, it returns an error.</p>
 </ul>
 <h4><a name="exists"><code>exists: func</code></a></h4>
 <p>Check if the key exists in the bucket.</p>
+<p>If the key exists in the bucket, it returns ok with true. If the key does
+not exist in the bucket, it returns ok with false.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="exists.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -634,6 +650,10 @@ If any other error occurs, it returns an error.</p>
 </ul>
 <h2><a name="wasi:keyvalue_atomic">Import interface wasi:keyvalue/atomic</a></h2>
 <p>A keyvalue interface that provides atomic operations.</p>
+<p>Atomic operations are single, indivisible operations. When a fault causes
+an atomic operation to fail, it will appear to the invoker of the atomic
+operation that the action either completed successfully or did nothing
+at all.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="bucket"><code>type bucket</code></a></h4>
@@ -649,7 +669,7 @@ If any other error occurs, it returns an error.</p>
 <h3>Functions</h3>
 <h4><a name="increment"><code>increment: func</code></a></h4>
 <p>Atomically increment the value associated with the key in the bucket by the
-given delta. It returns the new value.</p>
+given delta. It returns the new value. This is single, indivisible operation.</p>
 <p>If the key does not exist in the bucket, it creates a new key-value pair
 with the value set to the given delta.</p>
 <p>If any other error occurs, it returns an error.</p>
@@ -664,9 +684,13 @@ with the value set to the given delta.</p>
 <li><a name="increment.0"></a> result&lt;<code>u64</code>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="compare_and_swap"><code>compare-and-swap: func</code></a></h4>
-<p>Atomically compare and swap the value associated with the key in the bucket.
-It returns a boolean indicating if the swap was successful.</p>
-<p>If the key does not exist in the bucket, it returns an error.</p>
+<p>Compare-and-swap (CAS) atomically updates the value associated with the key
+in the bucket if the value matches the old value. This operation returns
+Ok(true) if the swap was successful, Ok(false) if the value did not match,</p>
+<p>A successful CAS operation means the current value matched the <code>old</code> value
+and was replaced with the <code>new</code> value.</p>
+<p>If the key does not exist in the bucket, it returns Ok(false).</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="compare_and_swap.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -680,6 +704,22 @@ It returns a boolean indicating if the swap was successful.</p>
 </ul>
 <h2><a name="wasi:keyvalue_batch">Import interface wasi:keyvalue/batch</a></h2>
 <p>A keyvalue interface that provides batch operations.</p>
+<p>A batch operation is an operation that operates on multiple keys at once.</p>
+<p>Batch operations are useful for reducing network round-trip time. For example,
+if you want to get the values associated with 100 keys, you can either do 100 get
+operations or you can do 1 batch get operation. The batch operation is
+faster because it only needs to make 1 network call instead of 100.</p>
+<p>A batch operation does not guarantee atomicity, meaning that if the batch
+operation fails, some of the keys may have been modified and some may not.
+Transactional operations are being worked on and will be added in the future to
+provide atomicity.</p>
+<p>Data consistency in a key value store refers to the gaurantee that once a
+write operation completes, all subsequent read operations will return the
+value that was written.</p>
+<p>The level of consistency in batch operations can vary depending on the
+implementation. This interface does not guarantee strong consistency, meaning
+that if a write operation completes, subsequent read operations may not return
+the value that was written.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="bucket"><code>type bucket</code></a></h4>
@@ -704,8 +744,12 @@ It returns a boolean indicating if the swap was successful.</p>
 <h3>Functions</h3>
 <h4><a name="get_many"><code>get-many: func</code></a></h4>
 <p>Get the values associated with the keys in the bucket. It returns a list of
-incoming-values that can be consumed to get the values.</p>
-<p>If any of the keys do not exist in the bucket, it returns an error.</p>
+incoming-value that can be consumed to get the value associated with the key.</p>
+<p>If any of the keys do not exist in the bucket, it returns an None value for
+that key in the list.</p>
+<p>Note that the key-value pairs are guaranteed to be returned in the same order</p>
+<p>MAY show an out-of-date value if there are concurrent writes to the bucket.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="get_many.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -713,23 +757,33 @@ incoming-values that can be consumed to get the values.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_many.0"></a> result&lt;list&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
+<li><a name="get_many.0"></a> result&lt;list&lt;option&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;&gt;&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="get_keys"><code>get-keys: func</code></a></h4>
 <p>Get all the keys in the bucket. It returns a list of keys.</p>
+<p>Note that the keys are not guaranteed to be returned in any particular order.</p>
+<p>If the bucket is empty, it returns an empty list.</p>
+<p>MAY show an out-of-date list of keys if there are concurrent writes to the bucket.</p>
+<p>If any error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="get_keys.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_keys.0"></a> <a href="#keys"><a href="#keys"><code>keys</code></a></a></li>
+<li><a name="get_keys.0"></a> result&lt;<a href="#keys"><a href="#keys"><code>keys</code></a></a>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="set_many"><code>set-many: func</code></a></h4>
 <p>Set the values associated with the keys in the bucket. If the key already
 exists in the bucket, it overwrites the value.</p>
-<p>If any of the keys do not exist in the bucket, it creates a new key-value pair.
-If any other error occurs, it returns an error.</p>
+<p>Note that the key-value pairs are not guaranteed to be set in the order
+they are provided.</p>
+<p>If any of the keys do not exist in the bucket, it creates a new key-value pair.</p>
+<p>If any other error occurs, it returns an error. When an error occurs, it
+does not rollback the key-value pairs that were already set. Thus, this batch operation
+does not guarantee atomicity, implying that some key-value pairs could be
+set while others might fail.</p>
+<p>Other concurrent operations may also be able to see the partial results.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="set_many.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -741,8 +795,14 @@ If any other error occurs, it returns an error.</p>
 </ul>
 <h4><a name="delete_many"><code>delete-many: func</code></a></h4>
 <p>Delete the key-value pairs associated with the keys in the bucket.</p>
-<p>If any of the keys do not exist in the bucket, it skips the key.
-If any other error occurs, it returns an error.</p>
+<p>Note that the key-value pairs are not guaranteed to be deleted in the order
+they are provided.</p>
+<p>If any of the keys do not exist in the bucket, it skips the key.</p>
+<p>If any other error occurs, it returns an error. When an error occurs, it
+does not rollback the key-value pairs that were already deleted. Thus, this batch operation
+does not guarantee atomicity, implying that some key-value pairs could be
+deleted while others might fail.</p>
+<p>Other concurrent operations may also be able to see the partial results.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="delete_many.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -767,8 +827,9 @@ If any other error occurs, it returns an error.</p>
 ----
 <h3>Functions</h3>
 <h4><a name="on_set"><code>on-set: func</code></a></h4>
-<p>Handle the set event for the given bucket and key.
-It returns a incoming-value that can be consumed to get the value.</p>
+<p>Handle the <a href="#set"><code>set</code></a> event for the given bucket and key.
+It returns a <a href="#incoming_value"><code>incoming-value</code></a> that represents the new value being set.
+The new value can be consumed by the handler.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="on_set.bucket"><a href="#bucket"><code>bucket</code></a></a>: own&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -776,7 +837,8 @@ It returns a incoming-value that can be consumed to get the value.</p>
 <li><a name="on_set.incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
 </ul>
 <h4><a name="on_delete"><code>on-delete: func</code></a></h4>
-<p>Handle the delete event for the given bucket and key.</p>
+<p>Handle the <a href="#delete"><code>delete</code></a> event for the given bucket and key.
+It returns a <a href="#key"><code>key</code></a> that represents the key being deleted.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="on_delete.bucket"><a href="#bucket"><code>bucket</code></a></a>: own&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>

--- a/keyvalue.md
+++ b/keyvalue.md
@@ -494,13 +494,16 @@ to the output-stream defined in the <code>wasi-io</code> interface.</p>
 <p>
 #### <a name="incoming_value">`resource incoming-value`</a>
 <p>A incoming-value is a wrapper around a value. It provides a way to read the value
-from the input-stream defined in the <code>wasi-io</code> interface.</p>
+from the <a href="#input_stream"><code>input-stream</code></a> defined in the <code>wasi-io</code> interface.</p>
 <p>The incoming-value provides two ways to consume the value:</p>
 <ol>
 <li><code>incoming-value-consume-sync</code> consumes the value synchronously and returns the
-value as a list of bytes.</li>
+value as a <code>list&lt;u8&gt;</code>.</li>
 <li><code>incoming-value-consume-async</code> consumes the value asynchronously and returns the
-value as an input-stream.</li>
+value as an <a href="#input_stream"><code>input-stream</code></a>.
+In addition, it provides a <code>incoming-value-size</code> function to get the size of the value.
+This is useful when the value is large and the caller wants to allocate a buffer of
+the right size to consume the value.</li>
 </ol>
 <h4><a name="incoming_value_async_body"><code>type incoming-value-async-body</code></a></h4>
 <p><a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></p>
@@ -511,6 +514,8 @@ value as an input-stream.</li>
 ----
 <h3>Functions</h3>
 <h4><a name="static_bucket.open_bucket"><code>[static]bucket.open-bucket: func</code></a></h4>
+<p>Opens a bucket with the given name.</p>
+<p>If any error occurs, including if the bucket does not exist, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="static_bucket.open_bucket.name"><code>name</code></a>: <code>string</code></li>
@@ -525,6 +530,8 @@ value as an input-stream.</li>
 <li><a name="static_outgoing_value.new_outgoing_value.0"></a> own&lt;<a href="#outgoing_value"><a href="#outgoing_value"><code>outgoing-value</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_outgoing_value.outgoing_value_write_body_async"><code>[method]outgoing-value.outgoing-value-write-body-async: func</code></a></h4>
+<p>Writes the value to the output-stream asynchronously.
+If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_outgoing_value.outgoing_value_write_body_async.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_value"><a href="#outgoing_value"><code>outgoing-value</code></a></a>&gt;</li>
@@ -534,6 +541,8 @@ value as an input-stream.</li>
 <li><a name="method_outgoing_value.outgoing_value_write_body_async.0"></a> result&lt;own&lt;<a href="#outgoing_value_body_async"><a href="#outgoing_value_body_async"><code>outgoing-value-body-async</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_outgoing_value.outgoing_value_write_body_sync"><code>[method]outgoing-value.outgoing-value-write-body-sync: func</code></a></h4>
+<p>Writes the value to the output-stream synchronously.
+If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_outgoing_value.outgoing_value_write_body_sync.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_value"><a href="#outgoing_value"><code>outgoing-value</code></a></a>&gt;</li>
@@ -544,6 +553,8 @@ value as an input-stream.</li>
 <li><a name="method_outgoing_value.outgoing_value_write_body_sync.0"></a> result&lt;_, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_incoming_value.incoming_value_consume_sync"><code>[method]incoming-value.incoming-value-consume-sync: func</code></a></h4>
+<p>Consumes the value synchronously and returns the value as a list of bytes.
+If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_value.incoming_value_consume_sync.self"><code>self</code></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
@@ -553,6 +564,8 @@ value as an input-stream.</li>
 <li><a name="method_incoming_value.incoming_value_consume_sync.0"></a> result&lt;<a href="#incoming_value_sync_body"><a href="#incoming_value_sync_body"><code>incoming-value-sync-body</code></a></a>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_incoming_value.incoming_value_consume_async"><code>[method]incoming-value.incoming-value-consume-async: func</code></a></h4>
+<p>Consumes the value asynchronously and returns the value as an <a href="#input_stream"><code>input-stream</code></a>.
+If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_value.incoming_value_consume_async.self"><code>self</code></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
@@ -561,14 +574,16 @@ value as an input-stream.</li>
 <ul>
 <li><a name="method_incoming_value.incoming_value_consume_async.0"></a> result&lt;own&lt;<a href="#incoming_value_async_body"><a href="#incoming_value_async_body"><code>incoming-value-async-body</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="method_incoming_value.size"><code>[method]incoming-value.size: func</code></a></h4>
+<h4><a name="method_incoming_value.incoming_value_size"><code>[method]incoming-value.incoming-value-size: func</code></a></h4>
+<p>The size of the value in bytes.
+If the size is unknown or unavailable, this function returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="method_incoming_value.size.self"><code>self</code></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
+<li><a name="method_incoming_value.incoming_value_size.self"><code>self</code></a>: borrow&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_incoming_value.size.0"></a> <code>u64</code></li>
+<li><a name="method_incoming_value.incoming_value_size.0"></a> result&lt;<code>u64</code>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h2><a name="wasi:keyvalue_readwrite">Import interface wasi:keyvalue/readwrite</a></h2>
 <p>A keyvalue interface that provides simple read and write operations.</p>

--- a/keyvalue.md
+++ b/keyvalue.md
@@ -672,7 +672,7 @@ at all.</p>
 <h3>Functions</h3>
 <h4><a name="increment"><code>increment: func</code></a></h4>
 <p>Atomically increment the value associated with the key in the bucket by the
-given delta. It returns the new value. This is single, indivisible operation.</p>
+given delta. It returns the new value. This is a single, indivisible operation.</p>
 <p>If the key does not exist in the bucket, it creates a new key-value pair
 with the value set to the given delta.</p>
 <p>If any other error occurs, it returns an error.</p>

--- a/keyvalue.md
+++ b/keyvalue.md
@@ -1,11 +1,19 @@
 <h1><a name="keyvalue">World keyvalue</a></h1>
+<p>The <code>wasi:keyvalue/keyvalue</code> world provides common APIs for interacting
+with key-value stores. Components targeting this world will be able to
+do</p>
+<ol>
+<li>CRUD (create, read, update, delete) operations on key-value stores.</li>
+<li>Atomic <a href="#increment"><code>increment</code></a> and CAS (compare-and-swap) operations.</li>
+<li>Batch operations that can reduce the number of round trips to the network.</li>
+</ol>
 <ul>
 <li>Imports:
 <ul>
 <li>interface <a href="#wasi:io_error_0.2.0_rc_2023_11_10"><code>wasi:io/error@0.2.0-rc-2023-11-10</code></a></li>
 <li>interface <a href="#wasi:io_poll_0.2.0_rc_2023_11_10"><code>wasi:io/poll@0.2.0-rc-2023-11-10</code></a></li>
 <li>interface <a href="#wasi:io_streams_0.2.0_rc_2023_11_10"><code>wasi:io/streams@0.2.0-rc-2023-11-10</code></a></li>
-<li>interface <a href="#wasi:keyvalue_wasi_cloud_error"><code>wasi:keyvalue/wasi-cloud-error</code></a></li>
+<li>interface <a href="#wasi:keyvalue_wasi_keyvalue_error"><code>wasi:keyvalue/wasi-keyvalue-error</code></a></li>
 <li>interface <a href="#wasi:keyvalue_types"><code>wasi:keyvalue/types</code></a></li>
 <li>interface <a href="#wasi:keyvalue_readwrite"><code>wasi:keyvalue/readwrite</code></a></li>
 <li>interface <a href="#wasi:keyvalue_atomic"><code>wasi:keyvalue/atomic</code></a></li>
@@ -414,12 +422,22 @@ is ready for reading, before performing the <code>splice</code>.</p>
 <ul>
 <li><a name="method_output_stream.blocking_splice.0"></a> result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
-<h2><a name="wasi:keyvalue_wasi_cloud_error">Import interface wasi:keyvalue/wasi-cloud-error</a></h2>
+<h2><a name="wasi:keyvalue_wasi_keyvalue_error">Import interface wasi:keyvalue/wasi-keyvalue-error</a></h2>
 <hr />
 <h3>Types</h3>
 <h4><a name="error"><code>resource error</code></a></h4>
-<h2>An error resource type for keyvalue operations.
-Currently, this provides only one function to return a string representation
+<p>An error resource type for keyvalue operations.</p>
+<p>Common errors:</p>
+<ul>
+<li>Connectivity errors (e.g. network errors): when the client cannot establish
+a connection to the keyvalue service.</li>
+<li>Autnetication and Authorization errors: when the client fails to authenticate
+or does not have the required permissions to perform the operation.</li>
+<li>Data errors: when the client sends incompatible or corrupted data.</li>
+<li>Resource errors: when the system runs out of resources (e.g. memory).</li>
+<li>Internal errors: unexpected errors on the server side.</li>
+</ul>
+<h2>Currently, this provides only one function to return a string representation
 of the error. In the future, this will be extended to provide more information
 about the error.</h2>
 <h3>Functions</h3>
@@ -577,9 +595,11 @@ value as an input-stream.</li>
 ----
 <h3>Functions</h3>
 <h4><a name="get"><code>get: func</code></a></h4>
-<p>Get the value associated with the key in the bucket. It returns a incoming-value
-that can be consumed to get the value.</p>
-<p>If the key does not exist in the bucket, it returns an error.</p>
+<p>Get the value associated with the key in the bucket.</p>
+<p>The value is returned as an option. If the key-value pair exists in the
+bucket, it returns ok with the value. If the key does not exist in the
+bucket, it returns ok with none.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="get.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -587,13 +607,13 @@ that can be consumed to get the value.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get.0"></a> result&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
+<li><a name="get.0"></a> result&lt;option&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="set"><code>set: func</code></a></h4>
 <p>Set the value associated with the key in the bucket. If the key already
 exists in the bucket, it overwrites the value.</p>
-<p>If the key does not exist in the bucket, it creates a new key-value pair.
-If any other error occurs, it returns an error.</p>
+<p>If the key does not exist in the bucket, it creates a new key-value pair.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="set.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -606,7 +626,8 @@ If any other error occurs, it returns an error.</p>
 </ul>
 <h4><a name="delete"><code>delete: func</code></a></h4>
 <p>Delete the key-value pair associated with the key in the bucket.</p>
-<p>If the key does not exist in the bucket, it returns an error.</p>
+<p>If the key does not exist in the bucket, it does nothing.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="delete.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -618,6 +639,9 @@ If any other error occurs, it returns an error.</p>
 </ul>
 <h4><a name="exists"><code>exists: func</code></a></h4>
 <p>Check if the key exists in the bucket.</p>
+<p>If the key exists in the bucket, it returns ok with true. If the key does
+not exist in the bucket, it returns ok with false.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="exists.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -629,6 +653,10 @@ If any other error occurs, it returns an error.</p>
 </ul>
 <h2><a name="wasi:keyvalue_atomic">Import interface wasi:keyvalue/atomic</a></h2>
 <p>A keyvalue interface that provides atomic operations.</p>
+<p>Atomic operations are single, indivisible operations. When a fault causes
+an atomic operation to fail, it will appear to the invoker of the atomic
+operation that the action either completed successfully or did nothing
+at all.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="bucket"><code>type bucket</code></a></h4>
@@ -644,7 +672,7 @@ If any other error occurs, it returns an error.</p>
 <h3>Functions</h3>
 <h4><a name="increment"><code>increment: func</code></a></h4>
 <p>Atomically increment the value associated with the key in the bucket by the
-given delta. It returns the new value.</p>
+given delta. It returns the new value. This is single, indivisible operation.</p>
 <p>If the key does not exist in the bucket, it creates a new key-value pair
 with the value set to the given delta.</p>
 <p>If any other error occurs, it returns an error.</p>
@@ -659,9 +687,13 @@ with the value set to the given delta.</p>
 <li><a name="increment.0"></a> result&lt;<code>u64</code>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="compare_and_swap"><code>compare-and-swap: func</code></a></h4>
-<p>Atomically compare and swap the value associated with the key in the bucket.
-It returns a boolean indicating if the swap was successful.</p>
-<p>If the key does not exist in the bucket, it returns an error.</p>
+<p>Compare-and-swap (CAS) atomically updates the value associated with the key
+in the bucket if the value matches the old value. This operation returns
+Ok(true) if the swap was successful, Ok(false) if the value did not match,</p>
+<p>A successful CAS operation means the current value matched the <code>old</code> value
+and was replaced with the <code>new</code> value.</p>
+<p>If the key does not exist in the bucket, it returns Ok(false).</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="compare_and_swap.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -675,6 +707,22 @@ It returns a boolean indicating if the swap was successful.</p>
 </ul>
 <h2><a name="wasi:keyvalue_batch">Import interface wasi:keyvalue/batch</a></h2>
 <p>A keyvalue interface that provides batch operations.</p>
+<p>A batch operation is an operation that operates on multiple keys at once.</p>
+<p>Batch operations are useful for reducing network round-trip time. For example,
+if you want to get the values associated with 100 keys, you can either do 100 get
+operations or you can do 1 batch get operation. The batch operation is
+faster because it only needs to make 1 network call instead of 100.</p>
+<p>A batch operation does not guarantee atomicity, meaning that if the batch
+operation fails, some of the keys may have been modified and some may not.
+Transactional operations are being worked on and will be added in the future to
+provide atomicity.</p>
+<p>Data consistency in a key value store refers to the gaurantee that once a
+write operation completes, all subsequent read operations will return the
+value that was written.</p>
+<p>The level of consistency in batch operations can vary depending on the
+implementation. This interface does not guarantee strong consistency, meaning
+that if a write operation completes, subsequent read operations may not return
+the value that was written.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="bucket"><code>type bucket</code></a></h4>
@@ -699,8 +747,12 @@ It returns a boolean indicating if the swap was successful.</p>
 <h3>Functions</h3>
 <h4><a name="get_many"><code>get-many: func</code></a></h4>
 <p>Get the values associated with the keys in the bucket. It returns a list of
-incoming-values that can be consumed to get the values.</p>
-<p>If any of the keys do not exist in the bucket, it returns an error.</p>
+incoming-value that can be consumed to get the value associated with the key.</p>
+<p>If any of the keys do not exist in the bucket, it returns an None value for
+that key in the list.</p>
+<p>Note that the key-value pairs are guaranteed to be returned in the same order</p>
+<p>MAY show an out-of-date value if there are concurrent writes to the bucket.</p>
+<p>If any other error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="get_many.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -708,23 +760,33 @@ incoming-values that can be consumed to get the values.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_many.0"></a> result&lt;list&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
+<li><a name="get_many.0"></a> result&lt;list&lt;option&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;&gt;&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="get_keys"><code>get-keys: func</code></a></h4>
 <p>Get all the keys in the bucket. It returns a list of keys.</p>
+<p>Note that the keys are not guaranteed to be returned in any particular order.</p>
+<p>If the bucket is empty, it returns an empty list.</p>
+<p>MAY show an out-of-date list of keys if there are concurrent writes to the bucket.</p>
+<p>If any error occurs, it returns an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="get_keys.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_keys.0"></a> <a href="#keys"><a href="#keys"><code>keys</code></a></a></li>
+<li><a name="get_keys.0"></a> result&lt;<a href="#keys"><a href="#keys"><code>keys</code></a></a>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="set_many"><code>set-many: func</code></a></h4>
 <p>Set the values associated with the keys in the bucket. If the key already
 exists in the bucket, it overwrites the value.</p>
-<p>If any of the keys do not exist in the bucket, it creates a new key-value pair.
-If any other error occurs, it returns an error.</p>
+<p>Note that the key-value pairs are not guaranteed to be set in the order
+they are provided.</p>
+<p>If any of the keys do not exist in the bucket, it creates a new key-value pair.</p>
+<p>If any other error occurs, it returns an error. When an error occurs, it
+does not rollback the key-value pairs that were already set. Thus, this batch operation
+does not guarantee atomicity, implying that some key-value pairs could be
+set while others might fail.</p>
+<p>Other concurrent operations may also be able to see the partial results.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="set_many.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -736,8 +798,14 @@ If any other error occurs, it returns an error.</p>
 </ul>
 <h4><a name="delete_many"><code>delete-many: func</code></a></h4>
 <p>Delete the key-value pairs associated with the keys in the bucket.</p>
-<p>If any of the keys do not exist in the bucket, it skips the key.
-If any other error occurs, it returns an error.</p>
+<p>Note that the key-value pairs are not guaranteed to be deleted in the order
+they are provided.</p>
+<p>If any of the keys do not exist in the bucket, it skips the key.</p>
+<p>If any other error occurs, it returns an error. When an error occurs, it
+does not rollback the key-value pairs that were already deleted. Thus, this batch operation
+does not guarantee atomicity, implying that some key-value pairs could be
+deleted while others might fail.</p>
+<p>Other concurrent operations may also be able to see the partial results.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="delete_many.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>

--- a/keyvalue.md
+++ b/keyvalue.md
@@ -431,7 +431,7 @@ is ready for reading, before performing the <code>splice</code>.</p>
 <ul>
 <li>Connectivity errors (e.g. network errors): when the client cannot establish
 a connection to the keyvalue service.</li>
-<li>Autnetication and Authorization errors: when the client fails to authenticate
+<li>Authentication and Authorization errors: when the client fails to authenticate
 or does not have the required permissions to perform the operation.</li>
 <li>Data errors: when the client sends incompatible or corrupted data.</li>
 <li>Resource errors: when the system runs out of resources (e.g. memory).</li>
@@ -482,9 +482,6 @@ can very depending on the specific implementation. For example,</p>
 <p><code>string</code></p>
 <p>A key is a unique identifier for a value in a bucket. The key is used to
 retrieve the value from the bucket.
-<h4><a name="keys"><code>type keys</code></a></h4>
-<p><a href="#keys"><a href="#keys"><code>keys</code></a></a></p>
-<p>A list of keys
 <h4><a name="outgoing_value"><code>resource outgoing-value</code></a></h4>
 <p>A value is the data stored in a key-value pair. The value can be of any type
 that can be represented in a byte array. It provides a way to write the value
@@ -575,6 +572,21 @@ value as an input-stream.</li>
 </ul>
 <h2><a name="wasi:keyvalue_readwrite">Import interface wasi:keyvalue/readwrite</a></h2>
 <p>A keyvalue interface that provides simple read and write operations.</p>
+<p>A read/write operation is an operation that acts on a single key-value pair.</p>
+<p>The value in the key-value pair is defined as a <code>u8</code> byte array and the intention
+is that it is the common denominator for all data types defined by different
+key-value stores to handle data, ensuring compatibility between different
+key-value stores. Note: the clients will be expecting serialization/deserialization overhead
+to be handled by the key-value store. The value could be a serialized object from
+JSON, HTML or vendor-specific data types like AWS S3 objects.</p>
+<p>Data consistency in a key value store refers to the gaurantee that once a
+write operation completes, all subsequent read operations will return the
+value that was written.</p>
+<p>The level of consistency in readwrite interfaces is <strong>eventual consistency</strong>,
+which means that if a write operation completes successfully, all subsequent
+read operations will eventually return the value that was written. In other words,
+if we pause the updates to the system, the system eventually will return
+the last updated value for read.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="bucket"><code>type bucket</code></a></h4>
@@ -597,9 +609,9 @@ value as an input-stream.</li>
 <h4><a name="get"><code>get: func</code></a></h4>
 <p>Get the value associated with the key in the bucket.</p>
 <p>The value is returned as an option. If the key-value pair exists in the
-bucket, it returns ok with the value. If the key does not exist in the
-bucket, it returns ok with none.</p>
-<p>If any other error occurs, it returns an error.</p>
+bucket, it returns <code>Ok(value)</code>. If the key does not exist in the
+bucket, it returns <code>Ok(none)</code>.</p>
+<p>If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="get.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -613,7 +625,7 @@ bucket, it returns ok with none.</p>
 <p>Set the value associated with the key in the bucket. If the key already
 exists in the bucket, it overwrites the value.</p>
 <p>If the key does not exist in the bucket, it creates a new key-value pair.</p>
-<p>If any other error occurs, it returns an error.</p>
+<p>If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="set.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -627,7 +639,7 @@ exists in the bucket, it overwrites the value.</p>
 <h4><a name="delete"><code>delete: func</code></a></h4>
 <p>Delete the key-value pair associated with the key in the bucket.</p>
 <p>If the key does not exist in the bucket, it does nothing.</p>
-<p>If any other error occurs, it returns an error.</p>
+<p>If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="delete.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -639,9 +651,9 @@ exists in the bucket, it overwrites the value.</p>
 </ul>
 <h4><a name="exists"><code>exists: func</code></a></h4>
 <p>Check if the key exists in the bucket.</p>
-<p>If the key exists in the bucket, it returns ok with true. If the key does
-not exist in the bucket, it returns ok with false.</p>
-<p>If any other error occurs, it returns an error.</p>
+<p>If the key exists in the bucket, it returns <code>Ok(true)</code>. If the key does
+not exist in the bucket, it returns <code>Ok(false)</code>.</p>
+<p>If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="exists.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -672,10 +684,10 @@ at all.</p>
 <h3>Functions</h3>
 <h4><a name="increment"><code>increment: func</code></a></h4>
 <p>Atomically increment the value associated with the key in the bucket by the
-given delta. It returns the new value. This is a single, indivisible operation.</p>
+given delta. It returns the new value.</p>
 <p>If the key does not exist in the bucket, it creates a new key-value pair
 with the value set to the given delta.</p>
-<p>If any other error occurs, it returns an error.</p>
+<p>If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="increment.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -689,11 +701,11 @@ with the value set to the given delta.</p>
 <h4><a name="compare_and_swap"><code>compare-and-swap: func</code></a></h4>
 <p>Compare-and-swap (CAS) atomically updates the value associated with the key
 in the bucket if the value matches the old value. This operation returns
-Ok(true) if the swap was successful, Ok(false) if the value did not match,</p>
+<code>Ok(true)</code> if the swap was successful, <code>Ok(false)</code> if the value did not match,</p>
 <p>A successful CAS operation means the current value matched the <code>old</code> value
 and was replaced with the <code>new</code> value.</p>
-<p>If the key does not exist in the bucket, it returns Ok(false).</p>
-<p>If any other error occurs, it returns an error.</p>
+<p>If the key does not exist in the bucket, it returns <code>Ok(false)</code>.</p>
+<p>If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="compare_and_swap.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
@@ -719,9 +731,9 @@ provide atomicity.</p>
 <p>Data consistency in a key value store refers to the gaurantee that once a
 write operation completes, all subsequent read operations will return the
 value that was written.</p>
-<p>The level of consistency in batch operations can vary depending on the
-implementation. This interface does not guarantee strong consistency, meaning
-that if a write operation completes, subsequent read operations may not return
+<p>The level of consistency in batch operations is <strong>eventual consistency</strong>, the same
+with the readwrite interface. This interface does not guarantee strong consistency,
+meaning that if a write operation completes, subsequent read operations may not return
 the value that was written.</p>
 <hr />
 <h3>Types</h3>
@@ -734,9 +746,6 @@ the value that was written.</p>
 #### <a name="key">`type key`</a>
 [`key`](#key)
 <p>
-#### <a name="keys">`type keys`</a>
-[`keys`](#keys)
-<p>
 #### <a name="incoming_value">`type incoming-value`</a>
 [`incoming-value`](#incoming_value)
 <p>
@@ -748,33 +757,33 @@ the value that was written.</p>
 <h4><a name="get_many"><code>get-many: func</code></a></h4>
 <p>Get the values associated with the keys in the bucket. It returns a list of
 incoming-value that can be consumed to get the value associated with the key.</p>
-<p>If any of the keys do not exist in the bucket, it returns an None value for
+<p>If any of the keys do not exist in the bucket, it returns a <code>none</code> value for
 that key in the list.</p>
 <p>Note that the key-value pairs are guaranteed to be returned in the same order</p>
 <p>MAY show an out-of-date value if there are concurrent writes to the bucket.</p>
-<p>If any other error occurs, it returns an error.</p>
+<p>If any other error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="get_many.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
-<li><a name="get_many.keys"><a href="#keys"><code>keys</code></a></a>: <a href="#keys"><a href="#keys"><code>keys</code></a></a></li>
+<li><a name="get_many.keys"><a href="#keys"><code>keys</code></a></a>: list&lt;<a href="#key"><a href="#key"><code>key</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
 <li><a name="get_many.0"></a> result&lt;list&lt;option&lt;own&lt;<a href="#incoming_value"><a href="#incoming_value"><code>incoming-value</code></a></a>&gt;&gt;&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="get_keys"><code>get-keys: func</code></a></h4>
+<h4><a name="keys"><code>keys: func</code></a></h4>
 <p>Get all the keys in the bucket. It returns a list of keys.</p>
 <p>Note that the keys are not guaranteed to be returned in any particular order.</p>
 <p>If the bucket is empty, it returns an empty list.</p>
 <p>MAY show an out-of-date list of keys if there are concurrent writes to the bucket.</p>
-<p>If any error occurs, it returns an error.</p>
+<p>If any error occurs, it returns an <code>Err(error)</code>.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="get_keys.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
+<li><a name="keys.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="get_keys.0"></a> result&lt;<a href="#keys"><a href="#keys"><code>keys</code></a></a>, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
+<li><a name="keys.0"></a> result&lt;list&lt;<a href="#key"><a href="#key"><code>key</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="set_many"><code>set-many: func</code></a></h4>
 <p>Set the values associated with the keys in the bucket. If the key already
@@ -782,7 +791,7 @@ exists in the bucket, it overwrites the value.</p>
 <p>Note that the key-value pairs are not guaranteed to be set in the order
 they are provided.</p>
 <p>If any of the keys do not exist in the bucket, it creates a new key-value pair.</p>
-<p>If any other error occurs, it returns an error. When an error occurs, it
+<p>If any other error occurs, it returns an <code>Err(error)</code>. When an error occurs, it
 does not rollback the key-value pairs that were already set. Thus, this batch operation
 does not guarantee atomicity, implying that some key-value pairs could be
 set while others might fail.</p>
@@ -801,7 +810,7 @@ set while others might fail.</p>
 <p>Note that the key-value pairs are not guaranteed to be deleted in the order
 they are provided.</p>
 <p>If any of the keys do not exist in the bucket, it skips the key.</p>
-<p>If any other error occurs, it returns an error. When an error occurs, it
+<p>If any other error occurs, it returns an <code>Err(error)</code>. When an error occurs, it
 does not rollback the key-value pairs that were already deleted. Thus, this batch operation
 does not guarantee atomicity, implying that some key-value pairs could be
 deleted while others might fail.</p>
@@ -809,7 +818,7 @@ deleted while others might fail.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="delete_many.bucket"><a href="#bucket"><code>bucket</code></a></a>: borrow&lt;<a href="#bucket"><a href="#bucket"><code>bucket</code></a></a>&gt;</li>
-<li><a name="delete_many.keys"><a href="#keys"><code>keys</code></a></a>: <a href="#keys"><a href="#keys"><code>keys</code></a></a></li>
+<li><a name="delete_many.keys"><a href="#keys"><code>keys</code></a></a>: list&lt;<a href="#key"><a href="#key"><code>key</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>

--- a/wit/atomic.wit
+++ b/wit/atomic.wit
@@ -14,18 +14,18 @@ interface atomic {
 	/// If the key does not exist in the bucket, it creates a new key-value pair
 	/// with the value set to the given delta. 
 	///
-	/// If any other error occurs, it returns an error.
+	/// If any other error occurs, it returns an `Err(error)`.
 	increment: func(bucket: borrow<bucket>, key: key, delta: u64) -> result<u64, error>;
 	
 	/// Compare-and-swap (CAS) atomically updates the value associated with the key
 	/// in the bucket if the value matches the old value. This operation returns
-	/// Ok(true) if the swap was successful, Ok(false) if the value did not match,
+	/// `Ok(true)` if the swap was successful, `Ok(false)` if the value did not match,
 	/// 
 	/// A successful CAS operation means the current value matched the `old` value
 	/// and was replaced with the `new` value.
 	///
-	/// If the key does not exist in the bucket, it returns Ok(false).
+	/// If the key does not exist in the bucket, it returns `Ok(false)`.
 	/// 
-	/// If any other error occurs, it returns an error.
+	/// If any other error occurs, it returns an `Err(error)`.
 	compare-and-swap: func(bucket: borrow<bucket>, key: key, old: u64, new: u64) -> result<bool, error>;
 }

--- a/wit/atomic.wit
+++ b/wit/atomic.wit
@@ -9,7 +9,7 @@ interface atomic {
 	use types.{bucket, error, key};
 
 	/// Atomically increment the value associated with the key in the bucket by the 
-	/// given delta. It returns the new value. This is single, indivisible operation.
+	/// given delta. It returns the new value. This is a single, indivisible operation.
 	///
 	/// If the key does not exist in the bucket, it creates a new key-value pair
 	/// with the value set to the given delta. 

--- a/wit/atomic.wit
+++ b/wit/atomic.wit
@@ -9,7 +9,7 @@ interface atomic {
 	use types.{bucket, error, key};
 
 	/// Atomically increment the value associated with the key in the bucket by the 
-	/// given delta. It returns the new value. This is a single, indivisible operation.
+	/// given delta. It returns the new value.
 	///
 	/// If the key does not exist in the bucket, it creates a new key-value pair
 	/// with the value set to the given delta. 

--- a/wit/atomic.wit
+++ b/wit/atomic.wit
@@ -1,10 +1,15 @@
 /// A keyvalue interface that provides atomic operations.
+/// 
+/// Atomic operations are single, indivisible operations. When a fault causes
+/// an atomic operation to fail, it will appear to the invoker of the atomic
+/// operation that the action either completed successfully or did nothing
+/// at all.
 interface atomic {
 	/// A keyvalue interface that provides atomic operations.
 	use types.{bucket, error, key};
 
 	/// Atomically increment the value associated with the key in the bucket by the 
-	/// given delta. It returns the new value.
+	/// given delta. It returns the new value. This is single, indivisible operation.
 	///
 	/// If the key does not exist in the bucket, it creates a new key-value pair
 	/// with the value set to the given delta. 
@@ -12,9 +17,15 @@ interface atomic {
 	/// If any other error occurs, it returns an error.
 	increment: func(bucket: borrow<bucket>, key: key, delta: u64) -> result<u64, error>;
 	
-	/// Atomically compare and swap the value associated with the key in the bucket.
-	/// It returns a boolean indicating if the swap was successful.
+	/// Compare-and-swap (CAS) atomically updates the value associated with the key
+	/// in the bucket if the value matches the old value. This operation returns
+	/// Ok(true) if the swap was successful, Ok(false) if the value did not match,
+	/// 
+	/// A successful CAS operation means the current value matched the `old` value
+	/// and was replaced with the `new` value.
 	///
-	/// If the key does not exist in the bucket, it returns an error.
+	/// If the key does not exist in the bucket, it returns Ok(false).
+	/// 
+	/// If any other error occurs, it returns an error.
 	compare-and-swap: func(bucket: borrow<bucket>, key: key, old: u64, new: u64) -> result<bool, error>;
 }

--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -27,14 +27,14 @@ interface batch {
 	/// Get the values associated with the keys in the bucket. It returns a list of
 	/// incoming-value that can be consumed to get the value associated with the key.
 	///
-	/// If any of the keys do not exist in the bucket, it returns an None value for
+	/// If any of the keys do not exist in the bucket, it returns a `none` value for
 	/// that key in the list.
 	/// 
 	/// Note that the key-value pairs are guaranteed to be returned in the same order
 	/// 
 	/// MAY show an out-of-date value if there are concurrent writes to the bucket.
 	/// 
-	/// If any other error occurs, it returns an error.
+	/// If any other error occurs, it returns an `Err(error)`.
 	get-many: func(bucket: borrow<bucket>, keys: keys) -> result<list<option<incoming-value>>, error>;
 
 	/// Get all the keys in the bucket. It returns a list of keys.
@@ -45,7 +45,7 @@ interface batch {
 	/// 
 	/// MAY show an out-of-date list of keys if there are concurrent writes to the bucket.
 	/// 
-	/// If any error occurs, it returns an error.
+	/// If any error occurs, it returns an `Err(error)`.
 	get-keys: func(bucket: borrow<bucket>) -> result<keys, error>;
 
 	/// Set the values associated with the keys in the bucket. If the key already
@@ -56,7 +56,7 @@ interface batch {
 	///
 	/// If any of the keys do not exist in the bucket, it creates a new key-value pair.
 	/// 
-	/// If any other error occurs, it returns an error. When an error occurs, it
+	/// If any other error occurs, it returns an `Err(error)`. When an error occurs, it
 	/// does not rollback the key-value pairs that were already set. Thus, this batch operation 
 	/// does not guarantee atomicity, implying that some key-value pairs could be 
 	/// set while others might fail. 
@@ -71,7 +71,7 @@ interface batch {
 	/// 
 	/// If any of the keys do not exist in the bucket, it skips the key.
 	/// 
-	/// If any other error occurs, it returns an error. When an error occurs, it
+	/// If any other error occurs, it returns an `Err(error)`. When an error occurs, it
 	/// does not rollback the key-value pairs that were already deleted. Thus, this batch operation
 	/// does not guarantee atomicity, implying that some key-value pairs could be
 	/// deleted while others might fail.

--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -16,9 +16,9 @@
 /// write operation completes, all subsequent read operations will return the
 /// value that was written.
 /// 
-/// The level of consistency in batch operations can vary depending on the 
-/// implementation. This interface does not guarantee strong consistency, meaning
-/// that if a write operation completes, subsequent read operations may not return
+/// The level of consistency in batch operations is **eventual consistency**, the same
+/// with the readwrite interface. This interface does not guarantee strong consistency, 
+/// meaning that if a write operation completes, subsequent read operations may not return
 /// the value that was written.
 interface batch {
 	/// A keyvalue interface that provides batch get operations.

--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -1,27 +1,81 @@
 /// A keyvalue interface that provides batch operations.
+/// 
+/// A batch operation is an operation that operates on multiple keys at once.
+/// 
+/// Batch operations are useful for reducing network round-trip time. For example, 
+/// if you want to get the values associated with 100 keys, you can either do 100 get
+/// operations or you can do 1 batch get operation. The batch operation is
+/// faster because it only needs to make 1 network call instead of 100.
+/// 
+/// A batch operation does not guarantee atomicity, meaning that if the batch
+/// operation fails, some of the keys may have been modified and some may not. 
+/// Transactional operations are being worked on and will be added in the future to
+/// provide atomicity.
+/// 
+/// Data consistency in a key value store refers to the gaurantee that once a 
+/// write operation completes, all subsequent read operations will return the
+/// value that was written.
+/// 
+/// The level of consistency in batch operations can vary depending on the 
+/// implementation. This interface does not guarantee strong consistency, meaning
+/// that if a write operation completes, subsequent read operations may not return
+/// the value that was written.
 interface batch {
 	/// A keyvalue interface that provides batch get operations.
 	use types.{bucket, error, key, keys, incoming-value, outgoing-value};
 
 	/// Get the values associated with the keys in the bucket. It returns a list of
-	/// incoming-values that can be consumed to get the values.
+	/// incoming-value that can be consumed to get the value associated with the key.
 	///
-	/// If any of the keys do not exist in the bucket, it returns an error.
-	get-many: func(bucket: borrow<bucket>, keys: keys) -> result<list<incoming-value>, error>;
+	/// If any of the keys do not exist in the bucket, it returns an None value for
+	/// that key in the list.
+	/// 
+	/// Note that the key-value pairs are guaranteed to be returned in the same order
+	/// 
+	/// MAY show an out-of-date value if there are concurrent writes to the bucket.
+	/// 
+	/// If any other error occurs, it returns an error.
+	get-many: func(bucket: borrow<bucket>, keys: keys) -> result<list<option<incoming-value>>, error>;
 
 	/// Get all the keys in the bucket. It returns a list of keys.
-	get-keys: func(bucket: borrow<bucket>) -> keys;
+	/// 
+	/// Note that the keys are not guaranteed to be returned in any particular order.
+	/// 
+	/// If the bucket is empty, it returns an empty list.
+	/// 
+	/// MAY show an out-of-date list of keys if there are concurrent writes to the bucket.
+	/// 
+	/// If any error occurs, it returns an error.
+	get-keys: func(bucket: borrow<bucket>) -> result<keys, error>;
 
 	/// Set the values associated with the keys in the bucket. If the key already
-	/// exists in the bucket, it overwrites the value.
+	/// exists in the bucket, it overwrites the value. 
+	/// 
+	/// Note that the key-value pairs are not guaranteed to be set in the order
+	/// they are provided. 
 	///
 	/// If any of the keys do not exist in the bucket, it creates a new key-value pair.
-	/// If any other error occurs, it returns an error.
+	/// 
+	/// If any other error occurs, it returns an error. When an error occurs, it
+	/// does not rollback the key-value pairs that were already set. Thus, this batch operation 
+	/// does not guarantee atomicity, implying that some key-value pairs could be 
+	/// set while others might fail. 
+	/// 
+	/// Other concurrent operations may also be able to see the partial results.
 	set-many: func(bucket: borrow<bucket>, key-values: list<tuple<key, borrow<outgoing-value>>>) -> result<_, error>;
 
 	/// Delete the key-value pairs associated with the keys in the bucket.
-	///
+	/// 
+	/// Note that the key-value pairs are not guaranteed to be deleted in the order
+	/// they are provided.
+	/// 
 	/// If any of the keys do not exist in the bucket, it skips the key.
-	/// If any other error occurs, it returns an error.
+	/// 
+	/// If any other error occurs, it returns an error. When an error occurs, it
+	/// does not rollback the key-value pairs that were already deleted. Thus, this batch operation
+	/// does not guarantee atomicity, implying that some key-value pairs could be
+	/// deleted while others might fail.
+	/// 
+	/// Other concurrent operations may also be able to see the partial results.
 	delete-many: func(bucket: borrow<bucket>, keys: keys) -> result<_, error>;
 }

--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -22,7 +22,7 @@
 /// the value that was written.
 interface batch {
 	/// A keyvalue interface that provides batch get operations.
-	use types.{bucket, error, key, keys, incoming-value, outgoing-value};
+	use types.{bucket, error, key, incoming-value, outgoing-value};
 
 	/// Get the values associated with the keys in the bucket. It returns a list of
 	/// incoming-value that can be consumed to get the value associated with the key.
@@ -35,7 +35,7 @@ interface batch {
 	/// MAY show an out-of-date value if there are concurrent writes to the bucket.
 	/// 
 	/// If any other error occurs, it returns an `Err(error)`.
-	get-many: func(bucket: borrow<bucket>, keys: keys) -> result<list<option<incoming-value>>, error>;
+	get-many: func(bucket: borrow<bucket>, keys: list<key>) -> result<list<option<incoming-value>>, error>;
 
 	/// Get all the keys in the bucket. It returns a list of keys.
 	/// 
@@ -46,7 +46,7 @@ interface batch {
 	/// MAY show an out-of-date list of keys if there are concurrent writes to the bucket.
 	/// 
 	/// If any error occurs, it returns an `Err(error)`.
-	get-keys: func(bucket: borrow<bucket>) -> result<keys, error>;
+	keys: func(bucket: borrow<bucket>) -> result<list<key>, error>;
 
 	/// Set the values associated with the keys in the bucket. If the key already
 	/// exists in the bucket, it overwrites the value. 
@@ -77,5 +77,5 @@ interface batch {
 	/// deleted while others might fail.
 	/// 
 	/// Other concurrent operations may also be able to see the partial results.
-	delete-many: func(bucket: borrow<bucket>, keys: keys) -> result<_, error>;
+	delete-many: func(bucket: borrow<bucket>, keys: list<key>) -> result<_, error>;
 }

--- a/wit/error.wit
+++ b/wit/error.wit
@@ -1,5 +1,15 @@
-interface wasi-cloud-error {
+interface wasi-keyvalue-error {
 	/// An error resource type for keyvalue operations.
+	/// 
+	/// Common errors:
+	/// - Connectivity errors (e.g. network errors): when the client cannot establish
+	///  a connection to the keyvalue service.
+	/// - Autnetication and Authorization errors: when the client fails to authenticate
+	///  or does not have the required permissions to perform the operation.
+	/// - Data errors: when the client sends incompatible or corrupted data.
+	/// - Resource errors: when the system runs out of resources (e.g. memory).
+	/// - Internal errors: unexpected errors on the server side.
+	/// 
 	/// Currently, this provides only one function to return a string representation
 	/// of the error. In the future, this will be extended to provide more information
 	/// about the error.

--- a/wit/error.wit
+++ b/wit/error.wit
@@ -4,7 +4,7 @@ interface wasi-keyvalue-error {
 	/// Common errors:
 	/// - Connectivity errors (e.g. network errors): when the client cannot establish
 	///  a connection to the keyvalue service.
-	/// - Autnetication and Authorization errors: when the client fails to authenticate
+	/// - Authentication and Authorization errors: when the client fails to authenticate
 	///  or does not have the required permissions to perform the operation.
 	/// - Data errors: when the client sends incompatible or corrupted data.
 	/// - Resource errors: when the system runs out of resources (e.g. memory).

--- a/wit/eventual-batch.wit
+++ b/wit/eventual-batch.wit
@@ -1,4 +1,4 @@
-/// A keyvalue interface that provides batch operations.
+/// A keyvalue interface that provides eventually consistent batch operations.
 /// 
 /// A batch operation is an operation that operates on multiple keys at once.
 /// 
@@ -20,7 +20,7 @@
 /// with the readwrite interface. This interface does not guarantee strong consistency, 
 /// meaning that if a write operation completes, subsequent read operations may not return
 /// the value that was written.
-interface batch {
+interface eventual-batch {
 	/// A keyvalue interface that provides batch get operations.
 	use types.{bucket, error, key, incoming-value, outgoing-value};
 

--- a/wit/eventual.wit
+++ b/wit/eventual.wit
@@ -1,6 +1,6 @@
-/// A keyvalue interface that provides simple read and write operations.
+/// A keyvalue interface that provides eventually consistent CRUD operations.
 /// 
-/// A read/write operation is an operation that acts on a single key-value pair.
+/// A CRUD operation is an operation that acts on a single key-value pair.
 /// 
 /// The value in the key-value pair is defined as a `u8` byte array and the intention
 /// is that it is the common denominator for all data types defined by different
@@ -18,7 +18,7 @@
 /// read operations will eventually return the value that was written. In other words,
 /// if we pause the updates to the system, the system eventually will return 
 /// the last updated value for read.
-interface readwrite {
+interface eventual {
 	/// A keyvalue interface that provides simple read and write operations.
 	use types.{bucket, error, incoming-value, key, outgoing-value};
 	

--- a/wit/handle-watch.wit
+++ b/wit/handle-watch.wit
@@ -1,12 +1,17 @@
 /// A keyvalue interface that provides handle-watch operations.
+/// 
+/// This interface is used to provide event-driven mechanisms to handle
+/// keyvalue changes.
 interface handle-watch {
 	/// A keyvalue interface that provides handle-watch operations.
 	use types.{bucket, key, incoming-value};
 
-	/// Handle the set event for the given bucket and key. 
-	/// It returns a incoming-value that can be consumed to get the value.
+	/// Handle the `set` event for the given bucket and key. 
+	/// It returns a `incoming-value` that represents the new value being set.
+	/// The new value can be consumed by the handler.
 	on-set: func(bucket: bucket, key: key, incoming-value: borrow<incoming-value>);
 
-	/// Handle the delete event for the given bucket and key.
+	/// Handle the `delete` event for the given bucket and key.
+	/// It returns a `key` that represents the key being deleted.
 	on-delete: func(bucket: bucket, key: key);
 }

--- a/wit/readwrite.wit
+++ b/wit/readwrite.wit
@@ -6,10 +6,10 @@ interface readwrite {
 	/// Get the value associated with the key in the bucket.
 	/// 
 	/// The value is returned as an option. If the key-value pair exists in the
-	/// bucket, it returns ok with the value. If the key does not exist in the
-	/// bucket, it returns ok with none. 
+	/// bucket, it returns `Ok(value)`. If the key does not exist in the
+	/// bucket, it returns `Ok(none)`. 
 	///
-	/// If any other error occurs, it returns an error.
+	/// If any other error occurs, it returns an `Err(error)`.
 	get: func(bucket: borrow<bucket>, key: key) -> result<option<incoming-value>, error>;
 
 	/// Set the value associated with the key in the bucket. If the key already
@@ -17,21 +17,21 @@ interface readwrite {
 	///
 	/// If the key does not exist in the bucket, it creates a new key-value pair.
 	/// 
-	/// If any other error occurs, it returns an error.
+	/// If any other error occurs, it returns an `Err(error)`.
 	set: func(bucket: borrow<bucket>, key: key, outgoing-value: borrow<outgoing-value>) -> result<_, error>;
 
 	/// Delete the key-value pair associated with the key in the bucket.
 	/// 
 	/// If the key does not exist in the bucket, it does nothing.
 	///
-	/// If any other error occurs, it returns an error.
+	/// If any other error occurs, it returns an `Err(error)`.
 	delete: func(bucket: borrow<bucket>, key: key) -> result<_, error>;
 
 	/// Check if the key exists in the bucket.
 	/// 
-	/// If the key exists in the bucket, it returns ok with true. If the key does
-	/// not exist in the bucket, it returns ok with false.
+	/// If the key exists in the bucket, it returns `Ok(true)`. If the key does
+	/// not exist in the bucket, it returns `Ok(false)`.
 	/// 
-	/// If any other error occurs, it returns an error.
+	/// If any other error occurs, it returns an `Err(error)`.
 	exists: func(bucket: borrow<bucket>, key: key) -> result<bool, error>;
 }

--- a/wit/readwrite.wit
+++ b/wit/readwrite.wit
@@ -3,24 +3,35 @@ interface readwrite {
 	/// A keyvalue interface that provides simple read and write operations.
 	use types.{bucket, error, incoming-value, key, outgoing-value};
 	
-	/// Get the value associated with the key in the bucket. It returns a incoming-value
-	/// that can be consumed to get the value.
+	/// Get the value associated with the key in the bucket.
+	/// 
+	/// The value is returned as an option. If the key-value pair exists in the
+	/// bucket, it returns ok with the value. If the key does not exist in the
+	/// bucket, it returns ok with none. 
 	///
-	/// If the key does not exist in the bucket, it returns an error.
-	get: func(bucket: borrow<bucket>, key: key) -> result<incoming-value, error>;
+	/// If any other error occurs, it returns an error.
+	get: func(bucket: borrow<bucket>, key: key) -> result<option<incoming-value>, error>;
 
 	/// Set the value associated with the key in the bucket. If the key already
 	/// exists in the bucket, it overwrites the value.
 	///
 	/// If the key does not exist in the bucket, it creates a new key-value pair.
+	/// 
 	/// If any other error occurs, it returns an error.
 	set: func(bucket: borrow<bucket>, key: key, outgoing-value: borrow<outgoing-value>) -> result<_, error>;
 
 	/// Delete the key-value pair associated with the key in the bucket.
+	/// 
+	/// If the key does not exist in the bucket, it does nothing.
 	///
-	/// If the key does not exist in the bucket, it returns an error.
+	/// If any other error occurs, it returns an error.
 	delete: func(bucket: borrow<bucket>, key: key) -> result<_, error>;
 
 	/// Check if the key exists in the bucket.
+	/// 
+	/// If the key exists in the bucket, it returns ok with true. If the key does
+	/// not exist in the bucket, it returns ok with false.
+	/// 
+	/// If any other error occurs, it returns an error.
 	exists: func(bucket: borrow<bucket>, key: key) -> result<bool, error>;
 }

--- a/wit/readwrite.wit
+++ b/wit/readwrite.wit
@@ -1,4 +1,23 @@
 /// A keyvalue interface that provides simple read and write operations.
+/// 
+/// A read/write operation is an operation that acts on a single key-value pair.
+/// 
+/// The value in the key-value pair is defined as a `u8` byte array and the intention
+/// is that it is the common denominator for all data types defined by different
+/// key-value stores to handle data, ensuring compatibility between different
+/// key-value stores. Note: the clients will be expecting serialization/deserialization overhead
+/// to be handled by the key-value store. The value could be a serialized object from
+/// JSON, HTML or vendor-specific data types like AWS S3 objects.
+/// 
+/// Data consistency in a key value store refers to the gaurantee that once a 
+/// write operation completes, all subsequent read operations will return the
+/// value that was written.
+/// 
+/// The level of consistency in readwrite interfaces is **eventual consistency**,
+/// which means that if a write operation completes successfully, all subsequent
+/// read operations will eventually return the value that was written. In other words,
+/// if we pause the updates to the system, the system eventually will return 
+/// the last updated value for read.
 interface readwrite {
 	/// A keyvalue interface that provides simple read and write operations.
 	use types.{bucket, error, incoming-value, key, outgoing-value};

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -17,6 +17,9 @@ interface types {
 	/// In this interface, we use the term `bucket` to refer to a collection of key-value
 	// Soon: switch to `resource bucket { ... }`
 	resource bucket {
+		/// Opens a bucket with the given name.
+		/// 
+		/// If any error occurs, including if the bucket does not exist, it returns an `Err(error)`.
 		open-bucket: static func(name: string) -> result<bucket, error>;
   	}
 	/// A key is a unique identifier for a value in a bucket. The key is used to
@@ -31,26 +34,38 @@ interface types {
 	// Soon: switch to `resource value { ... }`
 	resource outgoing-value {
 		new-outgoing-value: static func() -> outgoing-value;
+		/// Writes the value to the output-stream asynchronously.
+		/// If any other error occurs, it returns an `Err(error)`.
 		outgoing-value-write-body-async: func() -> result<outgoing-value-body-async, error>;
+		/// Writes the value to the output-stream synchronously.
+		/// If any other error occurs, it returns an `Err(error)`.
 		outgoing-value-write-body-sync: func(value: outgoing-value-body-sync) -> result<_, error>;
 	}
 	type outgoing-value-body-async = output-stream;
 	type outgoing-value-body-sync = list<u8>;
 
-
 	/// A incoming-value is a wrapper around a value. It provides a way to read the value
-	/// from the input-stream defined in the `wasi-io` interface.
+	/// from the `input-stream` defined in the `wasi-io` interface.
 	///
 	/// The incoming-value provides two ways to consume the value:
 	/// 1. `incoming-value-consume-sync` consumes the value synchronously and returns the
-	///    value as a list of bytes.
+	///    value as a `list<u8>`.
 	/// 2. `incoming-value-consume-async` consumes the value asynchronously and returns the
-	///    value as an input-stream.
+	///    value as an `input-stream`.
+	/// In addition, it provides a `incoming-value-size` function to get the size of the value.
+	/// This is useful when the value is large and the caller wants to allocate a buffer of
+	/// the right size to consume the value.
 	// Soon: switch to `resource incoming-value { ... }`
 	resource incoming-value {
+		/// Consumes the value synchronously and returns the value as a list of bytes.
+		/// If any other error occurs, it returns an `Err(error)`.
     	incoming-value-consume-sync: func() -> result<incoming-value-sync-body, error>;
+		/// Consumes the value asynchronously and returns the value as an `input-stream`.
+		/// If any other error occurs, it returns an `Err(error)`.
 	    incoming-value-consume-async: func() -> result<incoming-value-async-body, error>;
-	    size: func() -> u64;
+		/// The size of the value in bytes.
+		/// If the size is unknown or unavailable, this function returns an `Err(error)`.
+	    incoming-value-size: func() -> result<u64, error>;
 	}
     type incoming-value-async-body = input-stream;
     type incoming-value-sync-body = list<u8>;

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -27,7 +27,7 @@ interface types {
 	type keys = list<key>;
 
 	use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
-	use wasi-cloud-error.{ error };
+	use wasi-keyvalue-error.{ error };
 	/// A value is the data stored in a key-value pair. The value can be of any type
 	/// that can be represented in a byte array. It provides a way to write the value
 	/// to the output-stream defined in the `wasi-io` interface.

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -23,9 +23,6 @@ interface types {
 	/// retrieve the value from the bucket.
 	type key = string;
 
-	/// A list of keys
-	type keys = list<key>;
-
 	use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
 	use wasi-keyvalue-error.{ error };
 	/// A value is the data stored in a key-value pair. The value can be of any type

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,12 +1,12 @@
 package wasi:keyvalue;
 
-/// The `wasi:keyvalue/keyvalue` world provides common APIs for interacting
+/// The `wasi:keyvalue/imports` world provides common APIs for interacting
 /// with key-value stores. Components targeting this world will be able to
 /// do 
 /// 1. CRUD (create, read, update, delete) operations on key-value stores.
 /// 2. Atomic `increment` and CAS (compare-and-swap) operations.
 /// 3. Batch operations that can reduce the number of round trips to the network.
-world keyvalue {
+world imports {
 	/// The `readwrite` capability allows the component to perform CRUD
 	/// operations on the key-value store.
 	import readwrite;
@@ -21,6 +21,6 @@ world keyvalue {
 }
 
 world keyvalue-handle-watch {
-	include keyvalue;
+	include imports;
 	export handle-watch;
 }

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -7,17 +7,17 @@ package wasi:keyvalue;
 /// 2. Atomic `increment` and CAS (compare-and-swap) operations.
 /// 3. Batch operations that can reduce the number of round trips to the network.
 world imports {
-	/// The `readwrite` capability allows the component to perform CRUD
-	/// operations on the key-value store.
-	import readwrite;
+	/// The `eventual` capability allows the component to perform 
+	/// eventually consistent CRUD operations on the key-value store.
+	import eventual;
 
 	/// The `atomic` capability allows the component to perform atomic
 	/// `increment` and CAS (compare-and-swap) operations.
 	import atomic;
 
-	/// The `batch` capability allows the component to perform batch
-	/// operations that can reduce the number of round trips to the network.
-	import batch;
+	/// The `eventual-batch` capability allows the component to perform eventually
+	/// consistent batch operations that can reduce the number of round trips to the network.
+	import eventual-batch;
 }
 
 world keyvalue-handle-watch {

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,8 +1,22 @@
 package wasi:keyvalue;
 
+/// The `wasi:keyvalue/keyvalue` world provides common APIs for interacting
+/// with key-value stores. Components targeting this world will be able to
+/// do 
+/// 1. CRUD (create, read, update, delete) operations on key-value stores.
+/// 2. Atomic `increment` and CAS (compare-and-swap) operations.
+/// 3. Batch operations that can reduce the number of round trips to the network.
 world keyvalue {
+	/// The `readwrite` capability allows the component to perform CRUD
+	/// operations on the key-value store.
 	import readwrite;
+
+	/// The `atomic` capability allows the component to perform atomic
+	/// `increment` and CAS (compare-and-swap) operations.
 	import atomic;
+
+	/// The `batch` capability allows the component to perform batch
+	/// operations that can reduce the number of round trips to the network.
 	import batch;
 }
 


### PR DESCRIPTION
This commit has changed many function signatures to account for the scenario where the key does not exist. Instead of returning an error for non-existance keys, the expected behvaior should be returning a none for the client to handle.

The other changes are for providing more clarity to the behavior of the APIs ine `wasi:keyvalue` interfaces. It explained what it means to have batch operations without guarantees to atomicity and what are atomic operations like CAS.

It also changed the portability criteria to follow the newest WASI proposal template, and added a new goal regarding keyvalue operation performance in this proposal.

It also changed the `readwrite` and `batch` interface names to `eventual` and `eventual-batch` to indicate the operations are expected to run in an eventual consistent platform. 

Closes #24 #25 #9