### PR TITLE
`batch::get-many` should parallel `store.get`

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -304,7 +304,7 @@ list.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a id="get_many.0"></a> result&lt;list&lt;option&lt;(<code>string</code>, list&lt;<code>u8</code>&gt;)&gt;&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a id="get_many.0"></a> result&lt;list&lt;(<code>string</code>, option&lt;list&lt;<code>u8</code>&gt;&gt;)&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
 </ul>
 <h4><a id="set_many"></a><code>set-many: func</code></h4>
 <p>Set the values associated with the keys in the store. If the key already exists in the

--- a/watch-service.md
+++ b/watch-service.md
@@ -302,7 +302,7 @@ list.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a id="get_many.0"></a> result&lt;list&lt;option&lt;(<code>string</code>, list&lt;<code>u8</code>&gt;)&gt;&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a id="get_many.0"></a> result&lt;list&lt;(<code>string</code>, option&lt;list&lt;<code>u8</code>&gt;&gt;)&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
 </ul>
 <h4><a id="set_many"></a><code>set-many: func</code></h4>
 <p>Set the values associated with the keys in the store. If the key already exists in the

--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -29,7 +29,7 @@ interface batch {
     /// MAY show an out-of-date value if there are concurrent writes to the store.
     /// 
     /// If any other error occurs, it returns an `Err(error)`.
-    get-many: func(bucket: borrow<bucket>, keys: list<string>) -> result<list<option<tuple<string, list<u8>>>>, error>;
+    get-many: func(bucket: borrow<bucket>, keys: list<string>) -> result<list<tuple<string, option<list<u8>>>>, error>;
 
     /// Set the values associated with the keys in the store. If the key already exists in the
     /// store, it overwrites the value. 


### PR DESCRIPTION
```rust 
get: func(key: string) -> result<option<list<u8>>, error>;
``` 
in store returns an `option<list<u8>>`, but 
```rust
get-many: func(...) -> result<list<option<tuple<string, list<u8>>>>, error>;)
```
 in batch returns `list<option<tuple<string, list<u8>>>>`. I would expect `get-many` to return `result<list<tuple<string, option<list<u8>>>>, error>;`.