### PR TITLE
Clarify documentation for batch operations on unique keys

### DIFF
--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -6,6 +6,10 @@
 /// get the values associated with 100 unique keys, you can either do 100 get operations or you can
 /// do 1 batch get operation. The batch operation is faster because it only needs to make 1 network
 /// call instead of 100.
+///
+/// The keys passed to a batch operation should be unique. If the list contains duplicate keys,
+/// an implementation may return an error, may deduplicate them, or may process each occurrence
+/// independently.
 /// 
 /// A batch operation does not guarantee atomicity, meaning that if the batch operation fails, some
 /// of the keys may have been modified and some may not. 

--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -1,11 +1,11 @@
 /// A keyvalue interface that provides batch operations.
 /// 
-/// A batch operation is an operation that operates on multiple keys at once.
+/// A batch operation is an operation that operates on multiple unique keys at once.
 /// 
 /// Batch operations are useful for reducing network round-trip time. For example, if you want to
-/// get the values associated with 100 keys, you can either do 100 get operations or you can do 1
-/// batch get operation. The batch operation is faster because it only needs to make 1 network call
-/// instead of 100.
+/// get the values associated with 100 unique keys, you can either do 100 get operations or you can
+/// do 1 batch get operation. The batch operation is faster because it only needs to make 1 network
+/// call instead of 100.
 /// 
 /// A batch operation does not guarantee atomicity, meaning that if the batch operation fails, some
 /// of the keys may have been modified and some may not. 
@@ -20,7 +20,7 @@
 interface batch {
     use store.{bucket, error};
 
-    /// Get the key-value pairs associated with the keys in the store. It returns a list of
+    /// Get the key-value pairs associated with the unique keys in the store. It returns a list of
     /// key-value pairs.
     ///
     /// If any of the keys do not exist in the store, it returns a `none` value for that pair in the
@@ -31,7 +31,7 @@ interface batch {
     /// If any other error occurs, it returns an `Err(error)`.
     get-many: func(bucket: borrow<bucket>, keys: list<string>) -> result<list<option<tuple<string, list<u8>>>>, error>;
 
-    /// Set the values associated with the keys in the store. If the key already exists in the
+    /// Set the values associated with the unique keys in the store. If the key already exists in the
     /// store, it overwrites the value. 
     /// 
     /// Note that the key-value pairs are not guaranteed to be set in the order they are provided. 
@@ -46,7 +46,7 @@ interface batch {
     /// Other concurrent operations may also be able to see the partial results.
     set-many: func(bucket: borrow<bucket>, key-values: list<tuple<string, list<u8>>>) -> result<_, error>;
 
-    /// Delete the key-value pairs associated with the keys in the store.
+    /// Delete the key-value pairs associated with the unique keys in the store.
     /// 
     /// Note that the key-value pairs are not guaranteed to be deleted in the order they are
     /// provided.

--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -7,8 +7,9 @@
 /// do 1 batch get operation. The batch operation is faster because it only needs to make 1 network
 /// call instead of 100.
 ///
-/// The keys passed to a batch operation should be unique. If the list contains duplicate keys,
-/// an implementation may return an error, may deduplicate them, or may process each key independently.
+/// Callers SHOULD NOT pass duplicate keys to a batch operation. This interface does not
+/// define how duplicate keys are handled: implementations are not required to detect or
+/// reject them, and the resulting behavior may differ between backing stores.
 /// 
 /// A batch operation does not guarantee atomicity, meaning that if the batch operation fails, some
 /// of the keys may have been modified and some may not. 

--- a/wit/batch.wit
+++ b/wit/batch.wit
@@ -8,8 +8,7 @@
 /// call instead of 100.
 ///
 /// The keys passed to a batch operation should be unique. If the list contains duplicate keys,
-/// an implementation may return an error, may deduplicate them, or may process each occurrence
-/// independently.
+/// an implementation may return an error, may deduplicate them, or may process each key independently.
 /// 
 /// A batch operation does not guarantee atomicity, meaning that if the batch operation fails, some
 /// of the keys may have been modified and some may not. 


### PR DESCRIPTION
Stating that the keys in the batch operations should be unique, as the way to handle duplicated key varies across different KV store software (see below) and may cause inconsistent behavior in different wasi-keyvalue implementation.

#### Duplicate-key handling in batched get-many APIs

| Store | Batch API | Result shape | Duplicate keys | Class |
|---|---|---|---|---|
| DynamoDB | `BatchGetItem` | Item list, unordered | **Rejected** — `ValidationException`: "Provided list of item keys contains duplicates" | Rejected |
| Redis | `MGET`, `HMGET`, `JSON.MGET` | Array, len == argc | Preserved — one element per occurrence, in order | Positional |
| RocksDB (C++) | `MultiGet` | `PinnableSlice*` / vector, index-aligned | Preserved — explicitly *not* de-duplicated | Positional |
| HBase | `Table.get(List<Get>)` | `Result[]`, index-aligned | Preserved — one `Result` per input `Get` | Positional |
| Aerospike | batch read / `batch_operate` | Array, index maps to request | Preserved — each occurrence gets a slot | Positional |
| etcd v3 | `Txn` with N `Range` ops | One `RangeResponse` per op | Preserved — ops are independent (no key-list API) | Positional |
| FoundationDB | N concurrent `get()` futures | One future per call | Preserved — duplicates are just two futures | Positional |
| Memcached | `get k1 k2 k3` | Keyed `VALUE <key>` lines; misses omitted | Collapsed — clients build a dict | Collapsed |
| TiKV | `batch_get` | List of existing `KvPair`s; misses omitted | Collapsed | Collapsed |
| Cassandra / Scylla | `WHERE pk IN (...)` | Row set | Collapsed — each row returned once | Collapsed |
| MongoDB | `{_id: {$in: [...]}}` | Cursor of documents | Collapsed — one doc per match | Collapsed |
| Spanner | `Read` with `KeySet` | Row set | Collapsed — documented: treated as specified once | Collapsed |
| Hazelcast / Ignite / Infinispan | `getAll(Set<K>)` -> `Map<K,V>` | Map | Impossible — `Set` input forbids it at the type level | Collapsed |
| Caffeine / Guava | `getAll(Iterable<K>)` -> `Map<K,V>` | Map | Collapsed | Collapsed |
| RocksDB (Java, legacy) | `multiGet` -> `Map` | Map | Collapsed — contradicts C++ semantics; use `multiGetAsList` | Trap |
| RocksDB (Python) | `multi_get` -> `dict` | Dict | Collapsed — contradicts its own docstring | Trap |